### PR TITLE
Allow extractVibcCoreSmartContracts to be executed from CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "0.0.8-dev3",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-ibc/vibc-core-smart-contracts",
-      "version": "0.0.8-dev3",
+      "version": "0.0.9",
       "license": "UNLICENSED",
       "dependencies": {
         "@openzeppelin/contracts": "^4.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "vIBC Core Smart Contracts",
   "main": "dist/index.js",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,22 @@ export async function extractVibcCoreSmartContracts(contractsDir: string): Promi
     })
   } finally {
     // Delete the temporary directory
-    fs.rmSync(tempDir, { force: true, recursive: true })
+    fs.rmSync(tempDir, {force: true, recursive: true})
   }
+}
+
+if (require.main === module) {
+  const contractsDir = process.argv[2];
+  if (!contractsDir) {
+    console.error('Please provide a contracts directory as the first argument.');
+    process.exit(1);
+  }
+
+  extractVibcCoreSmartContracts(contractsDir)
+    .then(() => {
+      console.log('Extraction completed successfully.');
+    })
+    .catch(error => {
+      console.error('Error during extraction:', error);
+    });
 }


### PR DESCRIPTION
Allows to extract smart contracts by calling the `extractVibcCoreSmartContracts` from the command line like this:
`node dist/index.js .`