### PR TITLE
feat: support storing op consensus states of multiple heights

### DIFF
--- a/contracts/DummyVerifier.sol
+++ b/contracts/DummyVerifier.sol
@@ -27,7 +27,7 @@ contract DummyVerifier is ZKMintVerifier {
     }
 
     function verifyMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key,
         bytes calldata expectedValue
@@ -41,7 +41,7 @@ contract DummyVerifier is ZKMintVerifier {
     }
 
     function verifyNonMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key
     ) external pure override returns (bool) {

--- a/contracts/IbcVerifier.sol
+++ b/contracts/IbcVerifier.sol
@@ -4,15 +4,6 @@ pragma solidity ^0.8.0;
 import './IbcReceiver.sol';
 
 
-// OptimisticConsensusState contains the minimum information required
-// to perform membership proof for IBC messages.
-struct OptimisticConsensusState {
-    uint256 app_hash;
-    uint256 valset_hash;
-    uint256 time;
-    uint256 height;
-}
-
 // ConsensusState contains the complete information that can be used
 // to verify the next update for consensus state.
 //
@@ -39,14 +30,14 @@ interface ZKMintVerifier {
     ) external view returns (bool);
 
     function verifyMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key,
         bytes calldata expectedValue
     ) external pure returns (bool);
 
     function verifyNonMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key
     ) external pure returns (bool);

--- a/contracts/OpConsensusStateManager.sol
+++ b/contracts/OpConsensusStateManager.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import './IbcVerifier.sol';
+
+
+// OptimisticConsensusStateManager manages the appHash at different
+// heights and track the fraud proof end time for them.
+library OptimisticConsensusStateManager {
+    struct DataStore {
+        uint32 fraudProofWindowSeconds;
+
+        // consensusStates maps from the height to the appHash.
+        mapping(uint256 => uint256) consensusStates;
+
+        // fraudProofEndtime maps from the appHash to the fraud proof end time.
+        mapping(uint256 => uint256) fraudProofEndtime;
+    }
+
+    // addOpConsensusState adds an appHash to internal store and
+    // returns the fraud proof end time, and a bool flag indicating if
+    // the fraud proof window has passed according to the block's
+    // timestamp.
+    function addOpConsensusState(DataStore storage self, uint256 height, uint256 appHash)
+        external returns (uint256 fraudProofEndTime, bool ended) {
+        uint256 hash = self.consensusStates[height];
+        if (hash == 0) {
+            // a new appHash
+            self.consensusStates[height] = appHash;
+            uint256 endTime = block.timestamp + self.fraudProofWindowSeconds;
+            self.consensusStates[height] = appHash;
+            self.fraudProofEndtime[appHash] = endTime;
+            return (endTime, false);
+        }
+
+        if (hash == appHash) {
+            uint256 endTime = self.fraudProofEndtime[hash];
+            return (endTime, block.timestamp > endTime);
+        }
+
+        revert('cannot update a pending optimistic consensus state with a different appHash, please submit fraud proof instead');
+    }
+
+    // getState returns the appHash at the given height, and the fraud
+    // proof end time.
+    //
+    // 0 is returned if there isn't an appHash with the given height.
+    function getState(DataStore storage self, uint256 height) public
+        returns (uint256 appHash, uint256 fraudProofEndTime, bool ended) {
+        uint256 hash = self.consensusStates[height];
+        return (hash, self.fraudProofEndtime[hash], hash != 0 &&  block.timestamp > self.fraudProofEndtime[hash]);
+    }
+}

--- a/contracts/Verifier.sol
+++ b/contracts/Verifier.sol
@@ -29,17 +29,13 @@ contract Verifier is ZKMintVerifier {
     }
 
     function verifyMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key,
         bytes calldata expectedValue
     ) external pure override returns (bool) {
         require(key.length > 0, 'Key cannot be empty');
         require(expectedValue.length > 0, 'Expected value cannot be empty');
-        require(
-            consensusState.height >= proof.proofHeight.revision_height,
-            'Consensus state not sufficient for Merkle proof membership verification'
-        );
 
         // TODO: replace with real merkle verification logic
         // For now, a dummy proof verification is implemented
@@ -47,15 +43,11 @@ contract Verifier is ZKMintVerifier {
     }
 
     function verifyNonMembership(
-        OptimisticConsensusState calldata consensusState,
+        uint256 appHash,
         Proof calldata proof,
         bytes calldata key
     ) external pure override returns (bool) {
         require(key.length > 0, 'Key cannot be empty');
-        require(
-            consensusState.height >= proof.proofHeight.revision_height,
-            'Consensus state not sufficient for Merkle proof non-membership verification'
-        );
 
         // TODO: replace with real merkle verification logic
         // For now, a dummy proof verification is implemented

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,5 +4,6 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'forge-cache'
+gas_reports = ["*"]
 
 # See more config options https://book.getfoundry.sh/reference/config.html

--- a/test/OpConsensusStateManager.t.sol
+++ b/test/OpConsensusStateManager.t.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import 'forge-std/Test.sol';
+import '../contracts/OpConsensusStateManager.sol';
+
+contract OptimisticConsensusStateManagerCaller {
+    using OptimisticConsensusStateManager for OptimisticConsensusStateManager.DataStore;
+    OptimisticConsensusStateManager.DataStore private opConsensusStatesStore;
+
+    constructor() {
+        opConsensusStatesStore.fraudProofWindowSeconds = 1;
+    }
+
+    function addOpConsensusState(uint256 height, uint256 appHash)
+        external returns (uint256 fraudProofEndTime, bool ended){
+        return opConsensusStatesStore.addOpConsensusState(height, appHash);
+    }
+
+    function getState(uint256 height) external returns (uint256 appHash, uint256 fraudProofEndTime, bool ended) {
+        return opConsensusStatesStore.getState(height);
+    }
+}
+
+contract OptimisticConsensusStateManagerTest is Test {
+    OptimisticConsensusStateManagerCaller caller;
+    
+    function setUp() public {
+        caller = new OptimisticConsensusStateManagerCaller();
+    }
+
+    function test_addOpConsensusState_newOpConsensusStateCreatedWithPendingStatus() public {
+        (, bool ended) = caller.addOpConsensusState(1, 1);
+        assertEq(false, ended);
+    }
+
+    function test_addOpConsensusState_addingAlreadyTrustedOpConsensusStateIsNoop() public {
+        caller.addOpConsensusState(1, 1);
+
+        // fast forward time.
+        vm.warp(block.timestamp + 100);
+
+        // the fraud proof window has passed.
+        caller.addOpConsensusState(1, 1);
+
+        (, , bool ended) = caller.getState(1);
+        assertEq(true, ended);
+    }
+
+    function test_addOpConsensusState_addingPendingOpConsensusStateWithDifferentValuesIsError() public {
+        caller.addOpConsensusState(1, 1);
+
+        vm.expectRevert(bytes('cannot update a pending optimistic consensus state with a different appHash, please submit fraud proof instead'));
+        caller.addOpConsensusState(1, 2);
+    }
+
+    function test_addOpConsensusState_addingSameOpConsensusStateIsNoop() public {
+        caller.addOpConsensusState(1, 1);
+
+        (, uint256 originalFraudProofEndTime, ) = caller.getState(1);
+
+        vm.warp(block.timestamp + 1);
+
+        // adding the same appHash later doesn't update the fraud
+        // proof end time.
+        caller.addOpConsensusState(1, 1);
+        (, uint256 newFraudProofEndTime, ) = caller.getState(1);
+        assertEq(originalFraudProofEndTime, newFraudProofEndTime);
+    }
+
+    function test_getState_nonExist() public {
+        (uint256 appHash, , bool ended) = caller.getState(1);
+        assertEq(0, appHash);
+        assertEq(false, ended);
+    }
+}


### PR DESCRIPTION
## high level
- encapsute the op consensus state update logic in a separate class
- support querying the op consensus state at a specific height

related to #11 

## gas cost estimation
gas cost estimation for `addOpConsensusState`

- case: adding a new appHash, 50k
- case: adding the same appHash again, 1.6k

```
| test/OpConsensusStateManager.t.sol:OptimisticConsensusStateManagerCaller contract |                 |       |        |       |         |
|-----------------------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                                                   | Deployment Size |       |        |       |         |
| 156501                                                                            | 719             |       |        |       |         |
| Function Name                                                                     | min             | avg   | median | max   | # calls |
| addOpConsensusState                                                               | 50547           | 50547 | 50547  | 50547 | 1       |
```

```
| test/OpConsensusStateManager.t.sol:OptimisticConsensusStateManagerCaller contract |                 |       |        |       |         |
|-----------------------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                                                   | Deployment Size |       |        |       |         |
| 156501                                                                            | 719             |       |        |       |         |
| Function Name                                                                     | min             | avg   | median | max   | # calls |
| addOpConsensusState                                                               | 1608            | 26077 | 26077  | 50547 | 2       |
| getState                                                                          | 1799            | 1799  | 1799   | 1799  | 1       |
```

gas cost estimation for `getState`

- 1.80k in all cases

