### PR TITLE
feat: optimize contract size with custom error

### DIFF
--- a/contracts/Mars.sol
+++ b/contracts/Mars.sol
@@ -7,6 +7,8 @@ import './Ibc.sol';
 import './IbcReceiver.sol';
 import './IbcDispatcher.sol';
 
+error invalidCounterPartyPortId();
+
 contract Mars is IbcReceiver, Ownable {
     // received packet as chain B
     IbcPacket[] public recvedPackets;
@@ -44,7 +46,9 @@ contract Mars is IbcReceiver, Ownable {
         bytes32 counterpartyChannelId,
         string calldata counterpartyVersion
     ) external returns (string memory selectedVersion) {
-        require(bytes(counterpartyPortId).length > 8, 'Invalid counterpartyPortId');
+        if (bytes(counterpartyPortId).length <= 8) {
+            revert invalidCounterPartyPortId();
+        }
         /**
          * Version selection is determined by if the callback is invoked on behalf of ChanOpenInit or ChanOpenTry.
          * ChanOpenInit: self version should be provided whereas the counterparty version is empty.

--- a/test/fee.t.sol
+++ b/test/fee.t.sol
@@ -4,12 +4,14 @@ pragma solidity ^0.8.13;
 import 'forge-std/Test.sol';
 import 'forge-std/console.sol';
 import '../contracts/Ibc.sol';
-import {Dispatcher, InitClientMsg, UpgradeClientMsg} from '../contracts/Dispatcher.sol';
+import {invalidChannelType, Dispatcher, InitClientMsg, UpgradeClientMsg} from '../contracts/Dispatcher.sol';
 import {IbcReceiver} from '../contracts/IbcReceiver.sol';
 import '../contracts/IbcVerifier.sol';
 import '../contracts/Verifier.sol';
 import '../contracts/Mars.sol';
 import {PacketSenderTest} from './Dispatcher.t.sol';
+import "forge-std/console.sol";
+
 
 contract FeeTest is PacketSenderTest {
     address forwardRelayerPayee = deriveAddress('forward-payee');
@@ -81,7 +83,8 @@ contract FeeTest is PacketSenderTest {
     function test_must_incentivizedAck() public useFeeTestCases {
         vm.startPrank(relayer);
         sendPacket();
-        vm.expectRevert('invalid channel type: incentivized');
+        vm.expectRevert(abi.encodeWithSignature('invalidChannelType(string)',
+                                                'incentivized'));
         dispatcher.acknowledgement(IbcReceiver(mars), sentPacket, ackPacket, validProof);
     }
 


### PR DESCRIPTION
this change reduces the deployment size of the Dispatcher contract to below the threshold so that it is now deployable.

before the change:

Dispatcher contract size: 25.436, margin -0.86

after the change:

Dispatcher contract size: 24.332, margin 0.244

it fixes #13 
