### PR TITLE
add openIbcChannel function signature to IbcDispatcher

### DIFF
--- a/contracts/IbcDispatcher.sol
+++ b/contracts/IbcDispatcher.sol
@@ -13,6 +13,16 @@ import './IbcReceiver.sol';
 interface IbcDispatcher {
     function closeIbcChannel(bytes32 channelId) external;
 
+    function openIbcChannel(
+        IbcReceiver portAddress,
+        string calldata version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        CounterParty calldata counterparty,
+        Proof calldata proof
+    ) external;    
+
     function sendPacket(
         bytes32 channelId,
         bytes calldata payload,

--- a/contracts/Mars.sol
+++ b/contracts/Mars.sol
@@ -112,6 +112,19 @@ contract Mars is IbcReceiver, Ownable {
         dispatcher.closeIbcChannel(channelId);
     }
 
+    function initiateChannelHandshake(
+        IbcDispatcher dispatcher,
+        IbcReceiver portAddress,
+        string calldata version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        CounterParty calldata counterparty,
+        Proof calldata proof
+    ) external {
+        dispatcher.openIbcChannel(portAddress, version, ordering, feeEnabled,connectionHops, counterparty, proof);
+    }    
+
     function greet(
         IbcDispatcher dispatcher,
         string calldata message,


### PR DESCRIPTION
I've added the `openIbcChannel` function signature to the `IbcDispatcher` interface.

This enables the dApp to initiate a channel handshake from straight from the dApp, by calling the dispatcher **only having access to the IbcDispatcher ABI**. With current design, user would need to import entire Dispatcher ABI.

Mars contract has been updated with an example function `initiateChannelHandshake`