### PR TITLE
remove unused line from remappings.txt for hardhat compatibility

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -2,7 +2,6 @@
 @lazyledger/protobuf3-solidity-lib/=lib/protobuf3-solidity-lib/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-lib/forge-std:ds-test/=lib/forge-std/lib/ds-test/src/
 optimism/=lib/optimism/packages/contracts-bedrock/src/
 base64/=lib/base64
 proto/=lib/proto


### PR DESCRIPTION
In the [ibc-app-solidity-template repo](https://github.com/open-ibc/ibc-app-solidity-template) I'm enabling dual Hardhat/Foundry compatibility with Nomic's `hardhat-foundry ` npm package. It has trouble with this line in remappings.txt that is not used anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Reorganized the directory structure for improved management of libraries and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->