### PR TITLE
Raunak/multi client support

### DIFF
--- a/contracts/core/OpConsensusStateManager.sol
+++ b/contracts/core/OpConsensusStateManager.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import '../libs/Ibc.sol';
-import '../interfaces/ConsensusStateManager.sol';
-
+import {L1Header, ProofVerifier, OpL2StateProof, Ics23Proof} from '../interfaces/ProofVerifier.sol';
+import {ConsensusStateManager} from "../interfaces/ConsensusStateManager.sol";
 import {L1Block} from 'optimism/L2/L1Block.sol';
 
 // OptimisticConsensusStateManager manages the appHash at different

--- a/contracts/core/OpLightClient.sol
+++ b/contracts/core/OpLightClient.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import {L1Header, ProofVerifier, OpL2StateProof, Ics23Proof} from '../interfaces/ProofVerifier.sol';
-import {ConsensusStateManager} from "../interfaces/ConsensusStateManager.sol";
-import {L1Block} from 'optimism/L2/L1Block.sol';
+import {L1Header, ProofVerifier, OpL2StateProof, Ics23Proof} from "../interfaces/ProofVerifier.sol";
+import {LightClient} from "../interfaces/LightClient.sol";
+import {L1Block} from "optimism/L2/L1Block.sol";
 
-// OptimisticConsensusStateManager manages the appHash at different
+// OptimisticLightClient manages the appHash at different
 // heights and track the fraud proof end time for them.
-contract OptimisticConsensusStateManager is ConsensusStateManager {
+contract OptimisticLightClient is LightClient {
     // consensusStates maps from the height to the appHash.
     mapping(uint256 => uint256) public consensusStates;
 
@@ -39,11 +39,7 @@ contract OptimisticConsensusStateManager is ConsensusStateManager {
             // if this is a new apphash we need to verify the provided proof. This method will revert in case
             // of invalid proof.
             verifier.verifyStateUpdate(
-                l1header,
-                proof,
-                bytes32(appHash),
-                l1BlockProvider.hash(),
-                l1BlockProvider.number()
+                l1header, proof, bytes32(appHash), l1BlockProvider.hash(), l1BlockProvider.number()
             );
 
             // a new appHash
@@ -59,7 +55,7 @@ contract OptimisticConsensusStateManager is ConsensusStateManager {
         }
 
         revert(
-            'cannot update a pending optimistic consensus state with a different appHash, please submit fraud proof instead'
+            "cannot update a pending optimistic consensus state with a different appHash, please submit fraud proof instead"
         );
     }
 
@@ -72,9 +68,11 @@ contract OptimisticConsensusStateManager is ConsensusStateManager {
         return getInternalState(height);
     }
 
-    function getInternalState(
-        uint256 height
-    ) public view returns (uint256 appHash, uint256 fraudProofEndTime, bool ended) {
+    function getInternalState(uint256 height)
+        public
+        view
+        returns (uint256 appHash, uint256 fraudProofEndTime, bool ended)
+    {
         uint256 hash = consensusStates[height];
         return (hash, fraudProofEndtime[hash], hash != 0 && block.timestamp >= fraudProofEndtime[hash]);
     }
@@ -89,21 +87,20 @@ contract OptimisticConsensusStateManager is ConsensusStateManager {
      * can be used to perform the membership test and if so, it uses
      * the verifier to perform membership check.
      */
-    function verifyMembership(
-        Ics23Proof calldata proof,
-        bytes calldata key,
-        bytes calldata expectedValue
-    ) external view {
+    function verifyMembership(Ics23Proof calldata proof, bytes calldata key, bytes calldata expectedValue)
+        external
+        view
+    {
         // a proof generated at height H can only be verified against state root (app hash) from block H - 1.
         // this means the relayer must have updated the contract with the app hash from the previous block and
         // that is why we use proof.height - 1 here.
-        (uint256 appHash, , bool ended) = getInternalState(proof.height - 1);
+        (uint256 appHash,, bool ended) = getInternalState(proof.height - 1);
         require(ended, "appHash hasn't passed the fraud proof window");
         verifier.verifyMembership(bytes32(appHash), key, expectedValue, proof);
     }
 
     function verifyNonMembership(Ics23Proof calldata proof, bytes calldata key) external view {
-        (uint256 appHash, , bool ended) = getInternalState(proof.height - 1);
+        (uint256 appHash,, bool ended) = getInternalState(proof.height - 1);
         require(ended, "appHash hasn't passed the fraud proof window");
         verifier.verifyNonMembership(bytes32(appHash), key, proof);
     }

--- a/contracts/core/OpProofVerifier.sol
+++ b/contracts/core/OpProofVerifier.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.0;
 import {SecureMerkleTrie} from 'optimism/libraries/trie/SecureMerkleTrie.sol';
 import {RLPReader} from 'optimism/libraries/rlp/RLPReader.sol';
 import {RLPWriter} from 'optimism/libraries/rlp/RLPWriter.sol';
-
-import '../interfaces/ProofVerifier.sol';
+import {ProofVerifier, L1Header, OpL2StateProof, Ics23Proof, OpIcs23Proof} from '../interfaces/ProofVerifier.sol';
 
 contract OpProofVerifier is ProofVerifier {
     using RLPReader for RLPReader.RLPItem;

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.9;
 
-import '@openzeppelin/contracts/access/Ownable.sol';
-import '../interfaces/IbcDispatcher.sol';
-import '../interfaces/IbcMiddleware.sol';
-import {IbcReceiver} from '../interfaces/IbcReceiver.sol';
-import '../libs/Ibc.sol';
+import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
+import {IbcDispatcher} from '../interfaces/IbcDispatcher.sol';
+import {IbcMiddleware, IbcUniversalChannelMW, IbcUniversalPacketReceiver, IbcMwPacketReceiver , IbcMwEventsEmitter} from  '../interfaces/IbcMiddleware.sol';
+import {IbcReceiver, IbcReceiverBase} from '../interfaces/IbcReceiver.sol';
+import {ChannelOrder, CounterParty, IbcPacket, AckPacket, UniversalPacket, IbcUtils} from "../libs/Ibc.sol";
 
 contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
     constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}

--- a/contracts/examples/Earth.sol
+++ b/contracts/examples/Earth.sol
@@ -2,10 +2,8 @@
 
 pragma solidity ^0.8.9;
 
-import '../libs/Ibc.sol';
-import '../interfaces/IbcReceiver.sol';
-import '../interfaces/IbcDispatcher.sol';
-import '../interfaces/IbcMiddleware.sol';
+import {IbcUtils, UniversalPacket, AckPacket} from "../libs/Ibc.sol";
+import {IbcMwUser, IbcUniversalPacketReceiver, IbcUniversalPacketSender} from "../interfaces/IbcMiddleware.sol";
 
 contract Earth is IbcMwUser, IbcUniversalPacketReceiver {
     struct UcPacketWithChannel {
@@ -30,39 +28,36 @@ contract Earth is IbcMwUser, IbcUniversalPacketReceiver {
 
     function greet(address destPortAddr, bytes32 channelId, bytes calldata message, uint64 timeoutTimestamp) external {
         IbcUniversalPacketSender(mw).sendUniversalPacket(
-            channelId,
-            IbcUtils.toBytes32(destPortAddr),
-            message,
-            timeoutTimestamp
+            channelId, IbcUtils.toBytes32(destPortAddr), message, timeoutTimestamp
         );
     }
 
     // For testing only; real dApps should implment their own ack logic
-    function generateAckPacket(
-        bytes32,
-        address srcPortAddr,
-        bytes calldata appData
-    ) external view returns (AckPacket memory ackPacket) {
-        return AckPacket(true, abi.encodePacked(this, srcPortAddr, 'ack-', appData));
+    function generateAckPacket(bytes32, address srcPortAddr, bytes calldata appData)
+        external
+        view
+        returns (AckPacket memory ackPacket)
+    {
+        return AckPacket(true, abi.encodePacked(this, srcPortAddr, "ack-", appData));
     }
 
-    function onRecvUniversalPacket(
-        bytes32 channelId,
-        UniversalPacket calldata packet
-    ) external onlyIbcMw returns (AckPacket memory ackPacket) {
+    function onRecvUniversalPacket(bytes32 channelId, UniversalPacket calldata packet)
+        external
+        onlyIbcMw
+        returns (AckPacket memory ackPacket)
+    {
         recvedPackets.push(UcPacketWithChannel(channelId, packet));
         return this.generateAckPacket(channelId, IbcUtils.toAddress(packet.srcPortAddr), packet.appData);
     }
 
-    function onUniversalAcknowledgement(
-        bytes32 channelId,
-        UniversalPacket memory packet,
-        AckPacket calldata ack
-    ) external onlyIbcMw {
+    function onUniversalAcknowledgement(bytes32 channelId, UniversalPacket memory packet, AckPacket calldata ack)
+        external
+        onlyIbcMw
+    {
         // verify packet's destPortAddr is the ack's first encoded address. See generateAckPacket())
-        require(ack.data.length >= 20, 'ack data too short');
+        require(ack.data.length >= 20, "ack data too short");
         address ackSender = address(bytes20(ack.data[0:20]));
-        require(IbcUtils.toAddress(packet.destPortAddr) == ackSender, 'ack address mismatch');
+        require(IbcUtils.toAddress(packet.destPortAddr) == ackSender, "ack address mismatch");
         ackPackets.push(UcAckWithChannel(channelId, packet, ack));
     }
 

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import '../libs/Ibc.sol';
-import '../interfaces/IbcReceiver.sol';
-import '../interfaces/IbcDispatcher.sol';
+import {IBCErrors, AckPacket, ChannelOrder, CounterParty} from "../libs/Ibc.sol";
+import {IbcReceiverBase, IbcReceiver, IbcPacket} from "../interfaces/IbcReceiver.sol";
+import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
 
 contract Mars is IbcReceiverBase, IbcReceiver {
     // received packet as chain B
@@ -15,7 +15,7 @@ contract Mars is IbcReceiverBase, IbcReceiver {
     IbcPacket[] public timeoutPackets;
     bytes32[] public connectedChannels;
 
-    string[] supportedVersions = ['1.0', '2.0'];
+    string[] supportedVersions = ["1.0", "2.0"];
 
     constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}
 
@@ -40,7 +40,7 @@ contract Mars is IbcReceiverBase, IbcReceiver {
         CounterParty calldata counterparty
     ) external view onlyIbcDispatcher returns (string memory selectedVersion) {
         if (bytes(counterparty.portId).length <= 8) {
-            revert invalidCounterPartyPortId();
+            revert IBCErrors.invalidCounterPartyPortId();
         }
         /**
          * Version selection is determined by if the callback is invoked on behalf of ChanOpenInit or ChanOpenTry.
@@ -49,32 +49,30 @@ contract Mars is IbcReceiverBase, IbcReceiver {
          * In both cases, the selected version should be in the supported versions list.
          */
         bool foundVersion = false;
-        selectedVersion = keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked(''))
-            ? counterparty.version
-            : version;
+        selectedVersion =
+            keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")) ? counterparty.version : version;
         for (uint256 i = 0; i < supportedVersions.length; i++) {
             if (keccak256(abi.encodePacked(selectedVersion)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
                 foundVersion = true;
                 break;
             }
         }
-        require(foundVersion, 'Unsupported version');
+        require(foundVersion, "Unsupported version");
         // if counterpartyVersion is not empty, then it must be the same foundVersion
-        if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(''))) {
+        if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(""))) {
             require(
                 keccak256(abi.encodePacked(counterparty.version)) == keccak256(abi.encodePacked(selectedVersion)),
-                'Version mismatch'
+                "Version mismatch"
             );
         }
 
         return selectedVersion;
     }
 
-    function onConnectIbcChannel(
-        bytes32 channelId,
-        bytes32,
-        string calldata counterpartyVersion
-    ) external onlyIbcDispatcher {
+    function onConnectIbcChannel(bytes32 channelId, bytes32, string calldata counterpartyVersion)
+        external
+        onlyIbcDispatcher
+    {
         // ensure negotiated version is supported
         bool foundVersion = false;
         for (uint256 i = 0; i < supportedVersions.length; i++) {
@@ -83,7 +81,7 @@ contract Mars is IbcReceiverBase, IbcReceiver {
                 break;
             }
         }
-        require(foundVersion, 'Unsupported version');
+        require(foundVersion, "Unsupported version");
         connectedChannels.push(channelId);
     }
 
@@ -97,7 +95,7 @@ contract Mars is IbcReceiverBase, IbcReceiver {
                 break;
             }
         }
-        require(channelFound, 'Channel not found');
+        require(channelFound, "Channel not found");
     }
 
     /**
@@ -114,7 +112,6 @@ contract Mars is IbcReceiverBase, IbcReceiver {
      * @param channelId The ID of the channel to send the packet to.
      * @param timeoutTimestamp The timestamp at which the packet will expire if not received.
      */
-
     function greet(string calldata message, bytes32 channelId, uint64 timeoutTimestamp) external {
         dispatcher.sendPacket(channelId, bytes(message), timeoutTimestamp);
     }

--- a/contracts/interfaces/ConsensusStateManager.sol
+++ b/contracts/interfaces/ConsensusStateManager.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import '../libs/Ibc.sol';
-import './ProofVerifier.sol';
+import {Ics23Proof, L1Header, OpL2StateProof} from './ProofVerifier.sol';
 
 interface ConsensusStateManager {
     /**

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import '../libs/Ibc.sol';
-import './IbcReceiver.sol';
-import './ProofVerifier.sol';
+import {Height, CounterParty, ChannelOrder, AckPacket} from "../libs/Ibc.sol";
+import {IbcChannelReceiver} from "./IbcReceiver.sol";
+import {Ics23Proof} from "./ProofVerifier.sol";
 
 /**
  * @title IbcPacketSender
@@ -20,7 +20,7 @@ interface IbcPacketSender {
  * @author Polymer Labs
  * @notice IBC dispatcher interface is the Polymer Core Smart Contract that implements the core IBC protocol.
  * @dev IBC-compatible contracts depend on this interface to actively participate in the IBC protocol.
-        Other features are implemented as callback methods in the IbcReceiver interface.
+ *         Other features are implemented as callback methods in the IbcReceiver interface.
  */
 interface IbcDispatcher is IbcPacketSender {
     function portPrefix() external view returns (string memory);
@@ -81,10 +81,7 @@ interface IbcEventsEmitter {
     event RecvPacket(address indexed destPortAddress, bytes32 indexed destChannelId, uint64 sequence);
 
     event WriteAckPacket(
-        address indexed writerPortAddress,
-        bytes32 indexed writerChannelId,
-        uint64 sequence,
-        AckPacket ackPacket
+        address indexed writerPortAddress, bytes32 indexed writerChannelId, uint64 sequence, AckPacket ackPacket
     );
 
     event WriteTimeoutPacket(

--- a/contracts/interfaces/IbcMiddleware.sol
+++ b/contracts/interfaces/IbcMiddleware.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import '../libs/Ibc.sol';
-import './IbcDispatcher.sol';
-import './IbcReceiver.sol';
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {UniversalPacket, AckPacket} from "../libs/Ibc.sol";
+import {IbcPacketReceiver, IbcChannelReceiver} from "./IbcReceiver.sol";
 
 /**
  * @title IbcUniversalPacketSender
@@ -71,16 +71,12 @@ interface IbcMwPacketReceiver {
 
 // dApps and IBC middleware contracts need to implement this interface to receive universal channel packets as packets' final destination.
 interface IbcUniversalPacketReceiver {
-    function onRecvUniversalPacket(
-        bytes32 channelId,
-        UniversalPacket calldata ucPacket
-    ) external returns (AckPacket memory ackPacket);
+    function onRecvUniversalPacket(bytes32 channelId, UniversalPacket calldata ucPacket)
+        external
+        returns (AckPacket memory ackPacket);
 
-    function onUniversalAcknowledgement(
-        bytes32 channelId,
-        UniversalPacket memory packet,
-        AckPacket calldata ack
-    ) external;
+    function onUniversalAcknowledgement(bytes32 channelId, UniversalPacket memory packet, AckPacket calldata ack)
+        external;
 
     function onTimeoutUniversalPacket(bytes32 channelId, UniversalPacket calldata packet) external;
 }
@@ -105,9 +101,7 @@ interface IbcMiddlwareProvider is IbcUniversalPacketSender, IbcMwPacketSender {
  *   - IbcMiddleware must sit on top of a UniversalChannel MW or another IbcMiddleware.
  *   - IbcMiddleware cannnot own an IBC channel. Instead, UniversalChannel MW owns channels.
  */
-interface IbcMiddleware is IbcMiddlwareProvider, IbcMwPacketReceiver, IbcUniversalPacketReceiver {
-
-}
+interface IbcMiddleware is IbcMiddlwareProvider, IbcMwPacketReceiver, IbcUniversalPacketReceiver {}
 
 /**
  * @title IbcUniversalChannelMW
@@ -115,9 +109,7 @@ interface IbcMiddleware is IbcMiddlwareProvider, IbcMwPacketReceiver, IbcUnivers
  * IbcUniversalChannelMW is a special type of IbcMiddleware that owns IBC channels, which are multiplexed for other IbcMiddleware.
  * IbcUniversalChannelMW cannot sit on top of other MW, and must talk to IbcDispatcher directly.
  */
-interface IbcUniversalChannelMW is IbcMiddlwareProvider, IbcPacketReceiver, IbcChannelReceiver {
-
-}
+interface IbcUniversalChannelMW is IbcMiddlwareProvider, IbcPacketReceiver, IbcChannelReceiver {}
 
 /**
  * @title IbcMwEventsEmitter
@@ -220,7 +212,7 @@ contract IbcMwUser is Ownable {
      * Should add this modifier to all IBC-related callback functions.
      */
     modifier onlyIbcMw() {
-        require(authorizedMws[msg.sender], 'unauthorized IBC middleware');
+        require(authorizedMws[msg.sender], "unauthorized IBC middleware");
         _;
     }
 }

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.9;
 
-import '@openzeppelin/contracts/access/Ownable.sol';
-import './IbcDispatcher.sol';
-import '../libs/Ibc.sol';
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IbcDispatcher} from "./IbcDispatcher.sol";
+import {ChannelOrder, CounterParty, IbcPacket, AckPacket} from "../libs/Ibc.sol";
 
 /**
  * @title IbcChannelReceiver
@@ -19,17 +19,11 @@ interface IbcChannelReceiver {
         CounterParty calldata counterparty
     ) external returns (string memory selectedVersion);
 
-    function onConnectIbcChannel(
-        bytes32 channelId,
-        bytes32 counterpartyChannelId,
-        string calldata counterpartyVersion
-    ) external;
+    function onConnectIbcChannel(bytes32 channelId, bytes32 counterpartyChannelId, string calldata counterpartyVersion)
+        external;
 
-    function onCloseIbcChannel(
-        bytes32 channelId,
-        string calldata counterpartyPortId,
-        bytes32 counterpartyChannelId
-    ) external;
+    function onCloseIbcChannel(bytes32 channelId, string calldata counterpartyPortId, bytes32 counterpartyChannelId)
+        external;
 }
 
 /**
@@ -51,9 +45,7 @@ interface IbcPacketReceiver {
  * @notice IBC receiver interface must be implemented by a IBC-enabled contract.
  * The implementer, aka. dApp devs, should implement channel handshake and packet handling methods.
  */
-interface IbcReceiver is IbcChannelReceiver, IbcPacketReceiver {
-
-}
+interface IbcReceiver is IbcChannelReceiver, IbcPacketReceiver {}
 
 contract IbcReceiverBase is Ownable {
     IbcDispatcher public dispatcher;
@@ -76,7 +68,7 @@ contract IbcReceiverBase is Ownable {
      * Should add this modifier to all IBC-related callback functions.
      */
     modifier onlyIbcDispatcher() {
-        require(msg.sender == address(dispatcher), 'only IBC dispatcher');
+        require(msg.sender == address(dispatcher), "only IBC dispatcher");
         _;
     }
 }

--- a/contracts/interfaces/LightClient.sol
+++ b/contracts/interfaces/LightClient.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import {Ics23Proof, L1Header, OpL2StateProof} from './ProofVerifier.sol';
+import {Ics23Proof, L1Header, OpL2StateProof} from "./ProofVerifier.sol";
 
-interface ConsensusStateManager {
+interface LightClient {
     /**
      * addOpConsensusState adds an appHash to internal store and
      * returns the fraud proof end time, and a bool flag indicating if

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -209,6 +209,55 @@ library IbcUtils {
             result := mload(add(b, 32))
         }
     }
+
+    /**
+     * Convert a non-0x-prefixed hex string to an address
+     * @param hexStr hex string to convert to address. Note that the hex string must not include a 0x prefix.
+     * hexStr is case-insensitive.
+     */
+    function hexStrToAddress(string memory hexStr) public pure returns (address) {
+        if (bytes(hexStr).length != 40) {
+            revert IBCErrors.invalidHexStringLength();
+        }
+
+        bytes memory strBytes = bytes(hexStr);
+        bytes memory addrBytes = new bytes(20);
+
+        for (uint256 i = 0; i < 20; i++) {
+            uint8 high = uint8(strBytes[i * 2]);
+            uint8 low = uint8(strBytes[1 + i * 2]);
+            // Convert to lowercase if the character is in uppercase
+            if (high >= 65 && high <= 90) {
+                high += 32;
+            }
+            if (low >= 65 && low <= 90) {
+                low += 32;
+            }
+            uint8 digit = (high - (high >= 97 ? 87 : 48)) * 16 + (low - (low >= 97 ? 87 : 48));
+            addrBytes[i] = bytes1(digit);
+        }
+
+        address addr;
+        assembly {
+            addr := mload(add(addrBytes, 20))
+        }
+
+        return addr;
+    }
+
+    // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
+    // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
+    function isChannelOpenTry(CounterParty calldata counterparty) public returns (bool) {
+        if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
+            return false;
+            // ChanOpenInit with unknow conterparty
+        } else if (counterparty.channelId != bytes32(0) && bytes(counterparty.version).length != 0) {
+            // this is the ChanOpenTry; counterparty must not be zero-value
+            return true;
+        } else {
+            revert IBCErrors.invalidCounterParty();
+        }
+    }
 }
 
 contract Ibc {

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -151,6 +151,8 @@ library IBCErrors {
     // client related errors.
     error clientAlreadyCreated();
     error clientNotCreated();
+    error clientNotFound();
+    error invalidInput();
 
     // packet commitment related errors.
     error packetCommitmentNotFound();
@@ -247,7 +249,7 @@ library IbcUtils {
 
     // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
     // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
-    function isChannelOpenTry(CounterParty calldata counterparty) public returns (bool) {
+    function isChannelOpenTry(CounterParty calldata counterparty) public pure returns (bool) {
         if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
             return false;
             // ChanOpenInit with unknow conterparty

--- a/contracts/utils/DummyLightClient.sol
+++ b/contracts/utils/DummyLightClient.sol
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
-import '../interfaces/ConsensusStateManager.sol';
+import {LightClient, L1Header, OpL2StateProof, Ics23Proof} from "../interfaces/LightClient.sol";
 
 /**
- * @title DummyConsensusStateManager
+ * @title DummyLightClient
  * @dev This contract is a dummy implementation of a consensus state manager.
  *      It should only be used for testing purposes.
  *      The logic for checking if the proof length is greater than zero is naive.
  */
-
-contract DummyConsensusStateManager is ConsensusStateManager {
+contract DummyLightClient is LightClient {
     constructor() {}
 
-    function addOpConsensusState(
-        L1Header calldata,
-        OpL2StateProof calldata,
-        uint256,
-        uint256
-    ) external pure returns (uint256, bool) {
+    function addOpConsensusState(L1Header calldata, OpL2StateProof calldata, uint256, uint256)
+        external
+        pure
+        returns (uint256, bool)
+    {
         return (0, false);
     }
 
@@ -31,10 +29,10 @@ contract DummyConsensusStateManager is ConsensusStateManager {
     }
 
     function verifyMembership(Ics23Proof calldata proof, bytes memory, bytes memory) external pure {
-        require(proof.height > 0, 'Invalid dummy membership proof');
+        require(proof.height > 0, "Invalid dummy membership proof");
     }
 
     function verifyNonMembership(Ics23Proof calldata proof, bytes memory) external pure {
-        require(proof.height > 0, 'Invalid dummy non membership proof');
+        require(proof.height > 0, "Invalid dummy non membership proof");
     }
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 import "forge-std/Script.sol";
 import "../contracts/utils/DummyProofVerifier.sol";
-import "../contracts/utils/DummyConsensusStateManager.sol";
+import "../contracts/utils/DummyLightClient.sol";
 import "../contracts/core/Dispatcher.sol";
 import "../contracts/examples/Mars.sol";
 import "../contracts/core/OpProofVerifier.sol";
-import "../contracts/core/OpConsensusStateManager.sol";
+import "../contracts/core/OpLightClient.sol";
 import "../contracts/core/UniversalChannelHandler.sol";
 import "../contracts/examples/Earth.sol";
 
@@ -31,7 +31,7 @@ contract Deploy is Script {
 
         console.log("Deploying dummy contracts to %s...", chain);
 
-        address stateManager = deployDummyConsensusStateManager();
+        address stateManager = deployDummyLightClient();
         address dispatcher = deployDispatcher(portPrefix, stateManager);
         deployMars(dispatcher);
 
@@ -44,7 +44,7 @@ contract Deploy is Script {
 
         address l1BlockProvider = vm.envOr("L1_BLOCK_PROVIDER", 0x4200000000000000000000000000000000000015);
         uint32 fraudProofWindowSecs = 0;
-        address opStateManager = deployOpConsensusStateManager(fraudProofWindowSecs, proofVerifierAddr, l1BlockProvider);
+        address opStateManager = deployOpLightClient(fraudProofWindowSecs, proofVerifierAddr, l1BlockProvider);
 
         dispatcher = deployDispatcher(portPrefix, opStateManager);
         deployMars(dispatcher);
@@ -53,19 +53,23 @@ contract Deploy is Script {
         deployEarth(universalChannelHandler);
     }
 
-    function deployDummyConsensusStateManager() public broadcast returns (address addr_) {
-        DummyConsensusStateManager manager = new DummyConsensusStateManager{salt: _implSalt()}();
-        console.log("DummyConsensusStateManager deployed at %s", address(manager));
+    function deployDummyLightClient() public broadcast returns (address addr_) {
+        DummyLightClient manager = new DummyLightClient{salt: _implSalt()}();
+        console.log("DummyLightClient deployed at %s", address(manager));
         return address(manager);
     }
 
-    function deployDispatcher(string memory portPrefix, address stateManager_) public broadcast returns (address addr_)     {
-        Dispatcher dispatcher = new Dispatcher{salt: _implSalt()}(portPrefix, DummyConsensusStateManager(stateManager_));
+    function deployDispatcher(string memory portPrefix, address stateManager_)
+        public
+        broadcast
+        returns (address addr_)
+    {
+        Dispatcher dispatcher = new Dispatcher{salt: _implSalt()}(portPrefix, DummyLightClient(stateManager_));
         console.log("Dispatcher deployed at %s", address(dispatcher));
         return address(dispatcher);
     }
 
-    function deployMars(address dispatcher) public broadcast  returns (address addr_) {
+    function deployMars(address dispatcher) public broadcast returns (address addr_) {
         Mars mars = new Mars{salt: _implSalt()}(IbcDispatcher(dispatcher));
         console.log("Mars deployed at %s", address(mars));
         return address(mars);
@@ -77,19 +81,25 @@ contract Deploy is Script {
         return address(verifier);
     }
 
-    function deployOpConsensusStateManager(uint32 fraudProofWindowSecs, address proofVerifierAddr, address l1BlockProvider) public broadcast returns (address addr_) {
-        OptimisticConsensusStateManager manager = new OptimisticConsensusStateManager{salt: _implSalt()}(fraudProofWindowSecs, ProofVerifier(proofVerifierAddr), L1Block(l1BlockProvider));
-        console.log("OptimisticConsensusStateManager deployed at %s", address(manager));
+    function deployOpLightClient(uint32 fraudProofWindowSecs, address proofVerifierAddr, address l1BlockProvider)
+        public
+        broadcast
+        returns (address addr_)
+    {
+        OptimisticLightClient manager = new OptimisticLightClient{salt: _implSalt()}(
+            fraudProofWindowSecs, ProofVerifier(proofVerifierAddr), L1Block(l1BlockProvider)
+        );
+        console.log("OptimisticLightClient deployed at %s", address(manager));
         return address(manager);
     }
 
-    function deployUniversalChannelHandler(address dispatcher) public broadcast  returns (address addr_) {
+    function deployUniversalChannelHandler(address dispatcher) public broadcast returns (address addr_) {
         UniversalChannelHandler handler = new UniversalChannelHandler{salt: _implSalt()}(IbcDispatcher(dispatcher));
         console.log("UniversalChannelHandler deployed at %s", address(handler));
         return address(handler);
     }
 
-    function deployEarth(address middleware) public broadcast  returns (address addr_) {
+    function deployEarth(address middleware) public broadcast returns (address addr_) {
         Earth earth = new Earth{salt: _implSalt()}(middleware);
         console.log("Earth deployed at %s", address(earth));
         return address(earth);

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -8,8 +8,8 @@ import {Dispatcher} from '../contracts/core/Dispatcher.sol';
 import {IbcEventsEmitter} from '../contracts/interfaces/IbcDispatcher.sol';
 import {IbcChannelReceiver} from '../contracts/interfaces/IbcReceiver.sol';
 import '../contracts/examples/Mars.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
-import '../contracts/utils/DummyConsensusStateManager.sol';
+import '../contracts/core/OpLightClient.sol';
+import '../contracts/utils/DummyLightClient.sol';
 import '../contracts/core/OpProofVerifier.sol';
 
 struct LocalEnd {
@@ -36,10 +36,10 @@ contract Base is IbcEventsEmitter, ProofBase {
     Height ZERO_HEIGHT = Height(0, 0);
     uint64 maxTimeout = UINT64_MAX;
 
-    ConsensusStateManager opConsensusStateManager =
-        new OptimisticConsensusStateManager(1800, opProofVerifier, l1BlockProvider);
+    LightClient opLightClient =
+        new OptimisticLightClient(1800, opProofVerifier, l1BlockProvider);
 
-    ConsensusStateManager dummyConsStateManager = new DummyConsensusStateManager();
+    LightClient dummyConsStateManager = new DummyLightClient();
 
     Dispatcher dispatcher;
     string portPrefix = 'polyibc.eth.';

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -6,13 +6,13 @@ import {Dispatcher} from '../contracts/core/Dispatcher.sol';
 import {IbcEventsEmitter} from '../contracts/interfaces/IbcDispatcher.sol';
 import {IbcReceiver} from '../contracts/interfaces/IbcReceiver.sol';
 import '../contracts/examples/Mars.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
+import '../contracts/core/OpLightClient.sol';
 import './Dispatcher.base.t.sol';
 
 contract ClientTestBase is Base {
     function setUp() public virtual override {
         super.setUp();
-        dispatcher = new Dispatcher(portPrefix, opConsensusStateManager);
+        dispatcher = new Dispatcher(portPrefix, opLightClient);
     }
 }
 

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.15;
 
-import '../contracts/libs/Ibc.sol';
-import {Dispatcher} from '../contracts/core/Dispatcher.sol';
-import '../contracts/examples/Mars.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
-import './Proof.base.t.sol';
-import {stdStorage, StdStorage} from 'forge-std/Test.sol';
+import "../contracts/libs/Ibc.sol";
+import {Dispatcher} from "../contracts/core/Dispatcher.sol";
+import "../contracts/examples/Mars.sol";
+import {IbcDispatcher, IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
+import "../contracts/core/OpConsensusStateManager.sol";
+import "./Proof.base.t.sol";
+import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
 using stdStorage for StdStorage;
 
@@ -16,39 +17,39 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     OptimisticConsensusStateManager consensusStateManager;
 
     CounterParty ch0 =
-        CounterParty('polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e', IbcUtils.toBytes32('channel-0'), '1.0');
+        CounterParty("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
     CounterParty ch1 =
-        CounterParty('polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e', IbcUtils.toBytes32('channel-1'), '1.0');
-    string[] connectionHops0 = ['connection-0', 'connection-3'];
-    string[] connectionHops1 = ['connection-2', 'connection-1'];
+        CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
+    string[] connectionHops0 = ["connection-0", "connection-3"];
+    string[] connectionHops1 = ["connection-2", "connection-1"];
 
     function setUp() public override {
         super.setUp();
         consensusStateManager = new OptimisticConsensusStateManager(1, opProofVerifier, l1BlockProvider);
-        dispatcher = new Dispatcher('polyibc.eth1.', consensusStateManager);
+        dispatcher = new Dispatcher("polyibc.eth1.", consensusStateManager);
         mars = new Mars(dispatcher);
     }
 
     function test_ibc_channel_open_init() public {
-        CounterParty memory counterparty = CounterParty(ch1.portId, bytes32(0), '');
+        CounterParty memory counterparty = CounterParty(ch1.portId, bytes32(0), "");
 
         vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannel(address(mars), '1.0', ChannelOrder.NONE, false, connectionHops1, ch1.portId, bytes32(0));
+        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId, bytes32(0));
         // since this is open chann init, the proof is not used. so use an invalid one
         dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, counterparty, invalidProof);
     }
 
     function test_ibc_channel_open_try() public {
-        Ics23Proof memory proof = load_proof('/test/payload/channel_try_pending_proof.hex');
+        Ics23Proof memory proof = load_proof("/test/payload/channel_try_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannel(address(mars), '1.0', ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
+        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
 
         dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
     }
 
     function test_ibc_channel_ack() public {
-        Ics23Proof memory proof = load_proof('/test/payload/channel_ack_pending_proof.hex');
+        Ics23Proof memory proof = load_proof("/test/payload/channel_ack_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
         emit ConnectIbcChannel(address(mars), ch0.channelId);
@@ -57,7 +58,7 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function test_ibc_channel_confirm() public {
-        Ics23Proof memory proof = load_proof('/test/payload/channel_confirm_pending_proof.hex');
+        Ics23Proof memory proof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
         emit ConnectIbcChannel(address(mars), ch1.channelId);
@@ -66,30 +67,24 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function test_ack_packet() public {
-        Ics23Proof memory proof = load_proof('/test/payload/packet_ack_proof.hex');
+        Ics23Proof memory proof = load_proof("/test/payload/packet_ack_proof.hex");
 
         // plant a fake packet commitment so the ack checks go through
-        stdstore
-            .target(address(dispatcher))
-            .sig(dispatcher.sendPacketCommitment.selector)
-            .with_key(address(mars))
-            .with_key(ch0.channelId)
-            .with_key(uint256(1))
-            .checked_write(true);
+        stdstore.target(address(dispatcher)).sig(dispatcher.sendPacketCommitment.selector).with_key(address(mars))
+            .with_key(ch0.channelId).with_key(uint256(1)).checked_write(true);
 
         IbcPacket memory packet;
-        packet.data = bytes('packet-1');
+        packet.data = bytes("packet-1");
         packet.timeoutTimestamp = 15566401733896437760;
         packet.src.channelId = ch0.channelId;
-        packet.src.portId = string(abi.encodePacked('polyibc.eth1.', IbcUtils.toHexStr(address(mars))));
+        packet.src.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(mars))));
         packet.dest.portId = ch1.portId;
         packet.dest.channelId = ch1.channelId;
         packet.sequence = 1;
 
         // this data is taken from the write_acknowledgement event emitted by polymer
-        bytes memory ack = bytes(
-            '{"result":"eyAiYWNjb3VudCI6ICJhY2NvdW50IiwgInJlcGx5IjogImdvdCB0aGUgbWVzc2FnZSIgfQ=="}'
-        );
+        bytes memory ack =
+            bytes('{"result":"eyAiYWNjb3VudCI6ICJhY2NvdW50IiwgInJlcGx5IjogImdvdCB0aGUgbWVzc2FnZSIgfQ=="}');
 
         vm.expectEmit(true, true, true, true);
         emit Acknowledgement(address(mars), packet.src.channelId, packet.sequence);
@@ -98,14 +93,14 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function test_recv_packet() public {
-        Ics23Proof memory proof = load_proof('/test/payload/packet_commitment_proof.hex');
+        Ics23Proof memory proof = load_proof("/test/payload/packet_commitment_proof.hex");
 
         // this data is taken from polymerase/tests/e2e/tests/evm.events.test.ts MarsDappPair.createSentPacket()
         IbcPacket memory packet;
-        packet.data = bytes('packet-1');
+        packet.data = bytes("packet-1");
         packet.timeoutTimestamp = 15566401733896437760;
         packet.dest.channelId = ch1.channelId;
-        packet.dest.portId = string(abi.encodePacked('polyibc.eth1.', IbcUtils.toHexStr(address(mars))));
+        packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(mars))));
         packet.src.portId = ch0.portId;
         packet.src.channelId = ch0.channelId;
         packet.sequence = 1;
@@ -125,17 +120,12 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function load_proof(string memory filepath) internal returns (Ics23Proof memory) {
-        (bytes32 apphash, Ics23Proof memory proof) = abi.decode(
-            vm.parseBytes(vm.readFile(string.concat(rootDir, filepath))),
-            (bytes32, Ics23Proof)
-        );
+        (bytes32 apphash, Ics23Proof memory proof) =
+            abi.decode(vm.parseBytes(vm.readFile(string.concat(rootDir, filepath))), (bytes32, Ics23Proof));
 
         // this loads the app hash we got from the testing data into the consensus state manager internals
         // at the height it's supposed to go. That is, a block less than where the proof was generated from.
-        stdstore
-            .target(address(consensusStateManager))
-            .sig('consensusStates(uint256)')
-            .with_key(proof.height - 1)
+        stdstore.target(address(consensusStateManager)).sig("consensusStates(uint256)").with_key(proof.height - 1)
             .checked_write(apphash);
         // trick the fraud time window check
         vm.warp(block.timestamp + 1);

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -5,7 +5,7 @@ import "../contracts/libs/Ibc.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
 import "../contracts/examples/Mars.sol";
 import {IbcDispatcher, IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
-import "../contracts/core/OpConsensusStateManager.sol";
+import "../contracts/core/OpLightClient.sol";
 import "./Proof.base.t.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
 
@@ -14,7 +14,7 @@ using stdStorage for StdStorage;
 contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     Mars mars;
     Dispatcher dispatcher;
-    OptimisticConsensusStateManager consensusStateManager;
+    OptimisticLightClient consensusStateManager;
 
     CounterParty ch0 =
         CounterParty("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
@@ -25,7 +25,7 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
 
     function setUp() public override {
         super.setUp();
-        consensusStateManager = new OptimisticConsensusStateManager(1, opProofVerifier, l1BlockProvider);
+        consensusStateManager = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         dispatcher = new Dispatcher("polyibc.eth1.", consensusStateManager);
         mars = new Mars(dispatcher);
     }

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -6,7 +6,7 @@ import {Dispatcher} from '../contracts/core/Dispatcher.sol';
 import {IbcEventsEmitter} from '../contracts/interfaces/IbcDispatcher.sol';
 import {IbcReceiver} from '../contracts/interfaces/IbcReceiver.sol';
 import '../contracts/examples/Mars.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
+import '../contracts/core/OpLightClient.sol';
 import './Dispatcher.base.t.sol';
 
 contract ChannelHandshakeTest is Base {

--- a/test/OpConsensusStateManager.t.sol
+++ b/test/OpConsensusStateManager.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.0;
 
 import 'forge-std/Test.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
+import '../contracts/core/OpLightClient.sol';
 import '../contracts/utils/DummyProofVerifier.sol';
 import './Proof.base.t.sol';
 
-contract OptimisticConsensusStateManagerTest is ProofBase {
-    OptimisticConsensusStateManager manager;
+contract OptimisticLightClientTest is ProofBase {
+    OptimisticLightClient manager;
     ProofVerifier verifier;
 
     constructor() {
@@ -16,7 +16,7 @@ contract OptimisticConsensusStateManagerTest is ProofBase {
 
     function setUp() public override {
         super.setUp();
-        manager = new OptimisticConsensusStateManager(1, verifier, l1BlockProvider);
+        manager = new OptimisticLightClient(1, verifier, l1BlockProvider);
     }
 
     function test_addOpConsensusState_newOpConsensusStateCreatedWithPendingStatus() public {
@@ -63,7 +63,7 @@ contract OptimisticConsensusStateManagerTest is ProofBase {
     }
 
     function test_zero_proof_window() public {
-        manager = new OptimisticConsensusStateManager(0, verifier, l1BlockProvider);
+        manager = new OptimisticLightClient(0, verifier, l1BlockProvider);
         manager.addOpConsensusState(emptyl1header, invalidStateProof, 1, 1);
         (, , bool ended) = manager.getState(1);
         assertEq(true, ended);
@@ -76,12 +76,12 @@ contract OptimisticConsensusStateManagerTest is ProofBase {
     }
 }
 
-contract OptimisticConsensusStateManagerWithRealVerifierTest is ProofBase {
-    OptimisticConsensusStateManager manager;
+contract OptimisticLightClientWithRealVerifierTest is ProofBase {
+    OptimisticLightClient manager;
 
     function setUp() public override {
         super.setUp();
-        manager = new OptimisticConsensusStateManager(1, opProofVerifier, l1BlockProvider);
+        manager = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
     }
 
     function test_addOpConsensusState_newAppHashWithValidProof() public {

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -11,7 +11,7 @@ import {Mars} from '../contracts/examples/Mars.sol';
 import {Earth} from '../contracts/examples/Earth.sol';
 import {IbcMiddleware} from '../contracts/interfaces/IbcMiddleware.sol';
 import {GeneralMiddleware} from '../contracts/base/GeneralMiddleware.sol';
-import '../contracts/utils/DummyConsensusStateManager.sol';
+import '../contracts/utils/DummyLightClient.sol';
 
 struct ChannelSetting {
     ChannelOrder ordering;
@@ -54,7 +54,7 @@ contract VirtualChain is Test, IbcEventsEmitter {
     // ChannelIds are not initialized until channel handshake is started
     constructor(uint256 seed, string memory portPrefix) {
         _seed = seed;
-        dispatcher = new Dispatcher(portPrefix, new DummyConsensusStateManager());
+        dispatcher = new Dispatcher(portPrefix, new DummyLightClient());
         ucHandler = new UniversalChannelHandler(dispatcher);
 
         mars = new Mars(dispatcher);

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -7,7 +7,7 @@ import {IbcEventsEmitter} from '../contracts/interfaces/IbcDispatcher.sol';
 import {IbcReceiver} from '../contracts/interfaces/IbcReceiver.sol';
 import '../contracts/core/UniversalChannelHandler.sol';
 import '../contracts/examples/Mars.sol';
-import '../contracts/core/OpConsensusStateManager.sol';
+import '../contracts/core/OpLightClient.sol';
 import './Dispatcher.base.t.sol';
 import './VirtualChain.sol';
 


### PR DESCRIPTION
I took a cursory stab at:

- reducing contract size (through exporting functions to the `IbcUtils` library (we might still be just a hair above the contract size limit, but this can be solved by playing around with the solidity compiler) 
- renamed `consensusManager` -> `lightClient` as per @alfredo-stonk 's suggestion
- Added a mapping for getting a client id from a connectionId (assuming a client id will just start at 0, and increment from there? ), and also added a corresponding setter

I'm still wondering what the best way is to get the clientId to the `timeout`, `acknowledgement`, and `recvPacket` methods - these all require proving from a light client. Right now I just added an extra argument to all of these methods called `clientId`, though I'm not sure if this goes against the [IC4 spec](https://github.com/cosmos/ibc/blob/main/spec/core/ics-004-channel-and-packet-semantics/README.md#writing-acknowledgements) since that doesn't seem to give any client identifiers, or if this would make life hard for integrating these changes to our sequencer. From my understanding the portId contains the clientId as well, and each of these functions take a `IbcPacket` type, which has some port data associated with it - I think @alfredo-stonk said he might be thinking about what to do with the portID and how to decouple that from the dispatcher contract so that might also be relevant for this decision

Another thing I need to check is how to access the connection from the `connectionHops` array arguments given to `openIbcChannel`, `verifyConnectIbcChannelProof` , `connectIbcChannel` (right now I'm just taking the first index at each but need to understand this deeper)

I also still need to write unit tests in forge! and then after that will be the Sepolia deployment 