### PR TITLE
Gas optimisations

### DIFF
--- a/contracts/base/GeneralMiddleware.sol
+++ b/contracts/base/GeneralMiddleware.sol
@@ -68,7 +68,7 @@ contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter {
             ucPacket.destPortAddr,
             MW_ID,
             ucPacket.appData,
-            abi.encodePacked(MW_ID)
+            bytes.concat(bytes32(MW_ID))
         );
 
         if (mwIndex == mwAddrs.length - 1) {
@@ -104,7 +104,7 @@ contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter {
             ucPacket.destPortAddr,
             MW_ID,
             ucPacket.appData,
-            abi.encodePacked(MW_ID),
+            bytes.concat(bytes32(MW_ID)),
             ack
         );
 
@@ -136,7 +136,7 @@ contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter {
             ucPacket.destPortAddr,
             MW_ID,
             ucPacket.appData,
-            abi.encodePacked(MW_ID)
+            bytes.concat(bytes32(MW_ID))
         );
 
         if (mwIndex == mwAddrs.length - 1) {
@@ -184,7 +184,7 @@ contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter {
             MW_ID,
             appData,
             timeoutTimestamp,
-            abi.encodePacked(MW_ID)
+            bytes.concat(bytes32(MW_ID))
         );
 
         // send packet to next MW

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -520,8 +520,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable, Ibc {
         }
 
         // Not timeout yet, then do normal handling
-        IbcPacket memory pkt = packet;
-        AckPacket memory ack = receiver.onRecvPacket(pkt);
+        AckPacket memory ack = receiver.onRecvPacket(packet);
         bool hasAckPacketCommitment = packetCommitment[address(receiver)][packet.dest.channelId][packet.sequence].ackPacked;
         // check is not necessary for sync-acks
         if (hasAckPacketCommitment) {

--- a/contracts/core/OpConsensusStateManager.sol
+++ b/contracts/core/OpConsensusStateManager.sol
@@ -16,8 +16,8 @@ contract OptimisticConsensusStateManager is ConsensusStateManager {
     mapping(uint256 => uint256) fraudProofEndtime;
 
     uint256 fraudProofWindowSeconds;
-    ProofVerifier verifier;
-    L1Block l1BlockProvider;
+    ProofVerifier immutable verifier;
+    L1Block immutable l1BlockProvider;
 
     constructor(uint32 fraudProofWindowSeconds_, ProofVerifier verifier_, L1Block _l1BlockProvider) {
         fraudProofWindowSeconds = fraudProofWindowSeconds_;

--- a/contracts/core/OpProofVerifier.sol
+++ b/contracts/core/OpProofVerifier.sol
@@ -18,7 +18,7 @@ contract OpProofVerifier is ProofVerifier {
     uint internal constant L1_NUMBER_INDEX = 8;
 
     // @notice known L2 Output Oracle contract address to verify state update proofs against
-    address l2OutputOracleAddress;
+    address immutable l2OutputOracleAddress;
 
     constructor(address _l2OutputOracleAddress) {
         l2OutputOracleAddress = _l2OutputOracleAddress;

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -67,11 +67,15 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
     function onCloseIbcChannel(bytes32 channelId, string calldata, bytes32) external onlyIbcDispatcher {
         // logic to determin if the channel should be closed
         bool channelFound = false;
-        for (uint256 i = 0; i < connectedChannels.length; i++) {
+        for (uint256 i = 0; i < connectedChannels.length;) {
             if (connectedChannels[i] == channelId) {
                 delete connectedChannels[i];
                 channelFound = true;
                 break;
+            }
+
+            unchecked {
+                ++i;
             }
         }
         require(channelFound, 'Channel not found');

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -71,10 +71,10 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         // plant a fake packet commitment so the ack checks go through
         stdstore
             .target(address(dispatcher))
-            .sig(dispatcher.sendPacketCommitment.selector)
+            .sig(dispatcher.packetCommitment.selector)
             .with_key(address(mars))
             .with_key(ch0.channelId)
-            .with_key(uint256(1))
+            .with_key(uint256(1)) // SendPacked is stored as the first byte. (from right)
             .checked_write(true);
 
         IbcPacket memory packet;


### PR DESCRIPTION
Save ~85564 gas across function calls in the test suite. Most notisable improvements are found in Dispatcher.sol, with an average of 7% cost reductions with `recvPacket` seeing an 11% gas reduction.

For an overview of difference between gas reports, see:
https://docs.google.com/spreadsheets/d/1GHleuGHfqNIN7fHs8T7KiOKs8WH-fdGElh0ysYavanY/edit?usp=sharing

There are more savings to be hand with unchecked, however, I couldn't figure out the strict bonds. Over all: The implementation is already pretty optimised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new data structures for packet sequences and commitments in the Dispatcher contract.
	- Added `immutable` modifiers to critical variables across contracts for enhanced security and efficiency.
- **Refactor**
	- Improved data construction for packet transmission using `bytes.concat` in multiple contracts.
	- Optimized loop iterations in the Universal Channel Handler and Ibc contracts for better performance.
	- Reorganized mappings and updated constructor in the Dispatcher contract for clarity and functionality.
- **Bug Fixes**
	- Fixed loop progression issue in the Universal Channel Handler contract.
- **Tests**
	- Adjusted function signature in Dispatcher contract tests for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->