### PR TITLE
Raunak/testnet fixes

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -386,7 +386,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable, Ibc {
         IbcPacket memory pkt = packet;
         AckPacket memory ack;
         try receiver.onRecvPacket(pkt) returns (AckPacket memory receivedAck) {
-            ack = AckPacket(true, receivedAck.data);
+            ack = AckPacket(receivedAck.success, receivedAck.data);
         } catch {
             ack = AckPacket(false, ""); // Since the call to receiver.onRecvPacket failed; we have an empty ack data
         }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -130,6 +130,7 @@ contract RevertingStringMars is Mars {
         onlyIbcDispatcher
         returns (AckPacket memory ackPacket)
     {
+        // solhint-disable-next-line
         require(false, "on recv packet is reverting");
     }
 }
@@ -158,6 +159,7 @@ contract RevertingEmptyMars is Mars {
         onlyIbcDispatcher
         returns (AckPacket memory ackPacket)
     {
+        // solhint-disable-next-line
         require(false);
     }
 }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -19,7 +19,12 @@ contract Mars is IbcReceiverBase, IbcReceiver {
 
     constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}
 
-    function onRecvPacket(IbcPacket memory packet) external onlyIbcDispatcher returns (AckPacket memory ackPacket) {
+    function onRecvPacket(IbcPacket memory packet)
+        external
+        virtual
+        onlyIbcDispatcher
+        returns (AckPacket memory ackPacket)
+    {
         recvedPackets.push(packet);
 
         // solhint-disable-next-line quotes
@@ -109,5 +114,23 @@ contract Mars is IbcReceiverBase, IbcReceiver {
             }
         }
         revert UnsupportedVersion();
+    }
+}
+
+/**
+ * Exact same as Mars, but reverts - used to test that transport error is seperated from errors thrown in onRecvPacket
+ */
+contract RevertingMars is Mars {
+    error OnRecvPacketRevert();
+
+    constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
+
+    function onRecvPacket(IbcPacket memory packet)
+        external
+        override
+        onlyIbcDispatcher
+        returns (AckPacket memory ackPacket)
+    {
+        revert OnRecvPacketRevert();
     }
 }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -118,9 +118,23 @@ contract Mars is IbcReceiverBase, IbcReceiver {
 }
 
 /**
- * Exact same as Mars, but reverts - used to test that transport error is seperated from errors thrown in onRecvPacket
+ * These contracts are the exact same as Mars, but they revert/panick in different ways.
+ * they are used to test that transport error is seperated from errors thrown in onRecvPacket
  */
-contract RevertingMars is Mars {
+contract RevertingStringMars is Mars {
+    constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
+
+    function onRecvPacket(IbcPacket memory packet)
+        external
+        override
+        onlyIbcDispatcher
+        returns (AckPacket memory ackPacket)
+    {
+        require(false, "on recv packet is reverting");
+    }
+}
+
+contract RevertingBytesMars is Mars {
     error OnRecvPacketRevert();
 
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
@@ -132,5 +146,31 @@ contract RevertingMars is Mars {
         returns (AckPacket memory ackPacket)
     {
         revert OnRecvPacketRevert();
+    }
+}
+
+contract RevertingEmptyMars is Mars {
+    constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
+
+    function onRecvPacket(IbcPacket memory packet)
+        external
+        override
+        onlyIbcDispatcher
+        returns (AckPacket memory ackPacket)
+    {
+        require(false);
+    }
+}
+
+contract PanickingMars is Mars {
+    constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
+
+    function onRecvPacket(IbcPacket memory packet)
+        external
+        override
+        onlyIbcDispatcher
+        returns (AckPacket memory ackPacket)
+    {
+        assert(false);
     }
 }

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -174,7 +174,7 @@ library IbcUtils {
 
     // fromUniversalPacketBytes converts UniversalPacketDataBytes to UniversalPacketData, per how its packed into bytes
     function fromUniversalPacketBytes(bytes calldata data)
-        public
+        external
         pure
         returns (UniversalPacket memory universalPacketData)
     {

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -172,10 +172,6 @@ library IbcUtils {
 
     // convert params to UniversalPacketBytes with optimal gas cost
 
-    function toUniversalPacketBytes(UniversalPacket memory data) internal pure returns (bytes memory packetBytes) {
-        packetBytes = bytes.concat(data.srcPortAddr, bytes32(data.mwBitmap), data.destPortAddr, data.appData);
-    }
-
     // fromUniversalPacketBytes converts UniversalPacketDataBytes to UniversalPacketData, per how its packed into bytes
     function fromUniversalPacketBytes(bytes calldata data)
         public
@@ -195,6 +191,10 @@ library IbcUtils {
             destPortAddr := mload(0x0)
         }
         universalPacketData = UniversalPacket(srcPortAddr, uint256(mwBitmap), destPortAddr, data[96:data.length]);
+    }
+
+    function toUniversalPacketBytes(UniversalPacket memory data) internal pure returns (bytes memory packetBytes) {
+        packetBytes = bytes.concat(data.srcPortAddr, bytes32(data.mwBitmap), data.destPortAddr, data.appData);
     }
 
     // addressToPortId converts an address to a port ID

--- a/test/Ibc.t.sol
+++ b/test/Ibc.t.sol
@@ -57,4 +57,33 @@ contract IbcTest is Ibc, Test {
         assertFalse(parsederr.success);
         assertEq(bytes("this is an error message"), parsederr.data);
     }
+
+    function assert_Equal_Before_and_After_Encoding(address a1, uint256 mwBitmap, address a2, bytes memory appData)
+        internal
+    {
+        bytes memory afterEncoding = IbcUtils.toUniversalPacketBytes(
+            UniversalPacket(IbcUtils.toBytes32(a1), mwBitmap, IbcUtils.toBytes32(a2), appData)
+        );
+
+        UniversalPacket memory afterDecoding = IbcUtils.fromUniversalPacketBytes(afterEncoding);
+        assertEq(a1, IbcUtils.toAddress(afterDecoding.srcPortAddr));
+        assertEq(mwBitmap, afterDecoding.mwBitmap);
+        assertEq(a2, IbcUtils.toAddress(afterDecoding.destPortAddr));
+        assertEq(appData, afterDecoding.appData);
+    }
+
+    function test_To_From_UniversalPacketBytes() public {
+        // Standard
+        assert_Equal_Before_and_After_Encoding(vm.addr(1), uint256(123), vm.addr(2), "helloooo decode this for me ");
+        // empty string
+        assert_Equal_Before_and_After_Encoding(vm.addr(1), uint256(123), vm.addr(2), ""); // empty string
+
+        // Really long string:
+        assert_Equal_Before_and_After_Encoding(
+            vm.addr(1),
+            uint256(123),
+            vm.addr(2),
+            "daf;lkdsajflkasjdv;lkjzdljga;lkgfjda;iocjvz;lkjval;dsjkf;alkdj;zlkjv;lkjaeg;ijafd;lkjzvc,mnb.kahgd;ajkfaj;dgoij;zlckjv;lzkjv;kaldfjg;alkjgf;lkzvjcx;lkvja;lkjg;aslgjdz;adf;kasjg;lkjwaea;lkjg;io1j;4kjrda;lkfjaleot8ywp89yz;dvhlsdkj"
+        );
+    }
 }


### PR DESCRIPTION
PR to address:

-  handling errors in onRecvPacket callback in try/catch
- Change the encoding to/from UniversalChannelPackets to use bytes.concat (a non-deprecated version of `abi.encodePacked` ) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling in packet reception through the introduction of a `try-catch` block.
	- Added virtual function behavior and error handling in contracts for improved testing of transport errors.
	- Implemented a new method for handling data extraction in the `IbcUtils` library, optimizing for performance and reliability.
- **Tests**
	- Introduced new test cases to ensure robust packet reception and to validate the integrity of data encoding and decoding processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->