### PR TITLE
revert api split changes

### DIFF
--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -33,6 +33,17 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
         dispatcher.closeIbcChannel(channelId);
     }
 
+    // IBC callback functions
+    function onConnectIbcChannel(bytes32 channelId, bytes32, string calldata counterpartyVersion)
+        external
+        onlyIbcDispatcher
+    {
+        if (keccak256(abi.encodePacked(counterpartyVersion)) != keccak256(abi.encodePacked(VERSION))) {
+            revert UnsupportedVersion();
+        }
+        connectedChannels.push(channelId);
+    }
+
     function onCloseIbcChannel(bytes32 channelId, string calldata, bytes32) external onlyIbcDispatcher {
         // logic to determin if the channel should be closed
         bool channelFound = false;
@@ -138,43 +149,23 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
         mwStackAddrs[mwBitmap] = mwAddrs;
     }
 
-    // IBC callback functions
-    function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external onlyIbcDispatcher {
-        _connectChannel(channelId, counterpartyVersion);
-    }
-
-    function onChanOpenConfirm(bytes32 channelId, string calldata counterpartyVersion) external onlyIbcDispatcher {
-        _connectChannel(channelId, counterpartyVersion);
-    }
-
-    function onChanOpenInit(string calldata version)
-        external
-        view
-        onlyIbcDispatcher
-        returns (string memory selectedVersion)
-    {
-        return _openChannel(version);
-    }
-
-    function onChanOpenTry(string calldata counterpartyVersion)
-        external
-        view
-        onlyIbcDispatcher
-        returns (string memory selectedVersion)
-    {
-        return _openChannel(counterpartyVersion);
-    }
-
-    function _connectChannel(bytes32 channelId, string calldata version) private {
-        if (keccak256(abi.encodePacked(version)) != keccak256(abi.encodePacked(VERSION))) {
-            revert UnsupportedVersion();
-        }
-        connectedChannels.push(channelId);
-    }
-
-    function _openChannel(string calldata version) private pure returns (string memory selectedVersion) {
-        if (keccak256(abi.encodePacked(version)) != keccak256(abi.encodePacked(VERSION))) {
-            revert UnsupportedVersion();
+    function onOpenIbcChannel(
+        string calldata version,
+        ChannelOrder,
+        bool,
+        string[] calldata,
+        CounterParty calldata counterparty
+    ) external view onlyIbcDispatcher returns (string memory selectedVersion) {
+        if (counterparty.channelId == bytes32(0)) {
+            // ChanOpenInit
+            if (keccak256(abi.encodePacked(version)) != keccak256(abi.encodePacked(VERSION))) {
+                revert UnsupportedVersion();
+            }
+        } else {
+            // ChanOpenTry
+            if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(VERSION))) {
+                revert UnsupportedVersion();
+            }
         }
         return VERSION;
     }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -34,6 +34,22 @@ contract Mars is IbcReceiverBase, IbcReceiver {
         timeoutPackets.push(packet);
     }
 
+    function onConnectIbcChannel(bytes32 channelId, bytes32, string calldata counterpartyVersion)
+        external
+        onlyIbcDispatcher
+    {
+        // ensure negotiated version is supported
+        bool foundVersion = false;
+        for (uint256 i = 0; i < supportedVersions.length; i++) {
+            if (keccak256(abi.encodePacked(counterpartyVersion)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
+                foundVersion = true;
+                break;
+            }
+        }
+        if (!foundVersion) revert UnsupportedVersion();
+        connectedChannels.push(channelId);
+    }
+
     function onCloseIbcChannel(bytes32 channelId, string calldata, bytes32) external onlyIbcDispatcher {
         // logic to determin if the channel should be closed
         bool channelFound = false;
@@ -65,49 +81,39 @@ contract Mars is IbcReceiverBase, IbcReceiver {
         dispatcher.sendPacket(channelId, bytes(message), timeoutTimestamp);
     }
 
-    function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external onlyIbcDispatcher {
-        _connectChannel(channelId, counterpartyVersion);
-    }
-
-    function onChanOpenConfirm(bytes32 channelId, string calldata counterpartyVersion) external onlyIbcDispatcher {
-        _connectChannel(channelId, counterpartyVersion);
-    }
-
-    function onChanOpenInit(string calldata version)
-        external
-        view
-        onlyIbcDispatcher
-        returns (string memory selectedVersion)
-    {
-        return _openChannel(version);
-    }
-
-    function onChanOpenTry(string calldata counterpartyVersion)
-        external
-        view
-        onlyIbcDispatcher
-        returns (string memory selectedVersion)
-    {
-        return _openChannel(counterpartyVersion);
-    }
-
-    function _connectChannel(bytes32 channelId, string calldata counterpartyVersion) private {
-        // ensure negotiated version is supported
+    function onOpenIbcChannel(
+        string calldata version,
+        ChannelOrder,
+        bool,
+        string[] calldata,
+        CounterParty calldata counterparty
+    ) external view onlyIbcDispatcher returns (string memory selectedVersion) {
+        if (bytes(counterparty.portId).length <= 8) {
+            revert IBCErrors.invalidCounterPartyPortId();
+        }
+        /**
+         * Version selection is determined by if the callback is invoked on behalf of ChanOpenInit or ChanOpenTry.
+         * ChanOpenInit: self version should be provided whereas the counterparty version is empty.
+         * ChanOpenTry: counterparty version should be provided whereas the self version is empty.
+         * In both cases, the selected version should be in the supported versions list.
+         */
+        bool foundVersion = false;
+        selectedVersion =
+            keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")) ? counterparty.version : version;
         for (uint256 i = 0; i < supportedVersions.length; i++) {
-            if (keccak256(abi.encodePacked(counterpartyVersion)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
-                connectedChannels.push(channelId);
-                return;
+            if (keccak256(abi.encodePacked(selectedVersion)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
+                foundVersion = true;
+                break;
             }
         }
-        revert UnsupportedVersion();
-    }
-
-    function _openChannel(string calldata version) private view returns (string memory selectedVersion) {
-        for (uint256 i = 0; i < supportedVersions.length; i++) {
-            if (keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
-                return version;
+        if (!foundVersion) revert UnsupportedVersion();
+        // if counterpartyVersion is not empty, then it must be the same foundVersion
+        if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(""))) {
+            if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(selectedVersion))) {
+                revert VersionMismatch();
             }
         }
-        revert UnsupportedVersion();
+
+        return selectedVersion;
     }
 }

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -23,13 +23,14 @@ interface IbcPacketSender {
  *         Other features are implemented as callback methods in the IbcReceiver interface.
  */
 interface IbcDispatcher is IbcPacketSender {
-    function channelOpenInit(
+    function openIbcChannel(
         IbcChannelReceiver portAddress,
-        string calldata version,
+        CounterParty calldata self,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
-        string calldata counterpartyPortId
+        CounterParty calldata counterparty,
+        Ics23Proof calldata proof
     ) external;
 
     function closeIbcChannel(bytes32 channelId) external;
@@ -45,16 +46,7 @@ interface IbcEventsEmitter {
     //
     // channel events
     //
-    event ChannelOpenInit(
-        address indexed portAddress,
-        string version,
-        ChannelOrder ordering,
-        bool feeEnabled,
-        string[] connectionHops,
-        string counterpartyPortId
-    );
-
-    event ChannelOpenTry(
+    event OpenIbcChannel(
         address indexed portAddress,
         string version,
         ChannelOrder ordering,
@@ -64,9 +56,7 @@ interface IbcEventsEmitter {
         bytes32 counterpartyChannelId
     );
 
-    event ChannelOpenAck(address indexed portAddress, bytes32 channelId);
-
-    event ChannelOpenConfirm(address indexed portAddress, bytes32 channelId);
+    event ConnectIbcChannel(address indexed portAddress, bytes32 channelId);
 
     event CloseIbcChannel(address indexed portAddress, bytes32 indexed channelId);
 

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -12,13 +12,16 @@ import {ChannelOrder, CounterParty, IbcPacket, AckPacket} from "../libs/Ibc.sol"
  * handshake callbacks.
  */
 interface IbcChannelReceiver {
-    function onChanOpenInit(string calldata version) external returns (string memory selectedVersion);
+    function onOpenIbcChannel(
+        string calldata version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        CounterParty calldata counterparty
+    ) external returns (string memory selectedVersion);
 
-    function onChanOpenTry(string calldata counterpartyVersion) external returns (string memory selectedVersion);
-
-    function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external;
-
-    function onChanOpenConfirm(bytes32 channelId, string calldata counterpartyVersion) external;
+    function onConnectIbcChannel(bytes32 channelId, bytes32 counterpartyChannelId, string calldata counterpartyVersion)
+        external;
 
     function onCloseIbcChannel(bytes32 channelId, string calldata counterpartyPortId, bytes32 counterpartyChannelId)
         external;
@@ -50,6 +53,7 @@ contract IbcReceiverBase is Ownable {
 
     error notIbcDispatcher();
     error UnsupportedVersion();
+    error VersionMismatch();
     error ChannelNotFound();
 
     /**

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -65,50 +65,35 @@ contract Base is IbcEventsEmitter, ProofBase {
     // ⬇️ IBC functions for testing
 
     /**
-     * @dev Step-1 of the 4-step handshake to open an IBC channel.
+     * @dev Step-1/2 of the 4-step handshake to open an IBC channel.
      * @param le Local end settings for the channel.
      * @param re Remote end settings for the channel.
      * @param s Channel handshake settings.
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function channelOpenInit(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
+    function openChannel(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
         public
     {
-        if (expPass) {
-            vm.expectEmit(true, true, true, true);
-            emit ChannelOpenInit(
-                address(le.receiver), le.versionExpected, s.ordering, s.feeEnabled, le.connectionHops, re.portId
-            );
+        CounterParty memory cp;
+        cp.portId = re.portId;
+        if (!s.localInitiate) {
+            cp.channelId = re.channelId;
+            cp.version = re.version;
         }
-        dispatcher.channelOpenInit(le.receiver, le.versionCall, s.ordering, s.feeEnabled, le.connectionHops, re.portId);
-    }
-
-    /**
-     * @dev Step-2 of the 4-step handshake to open an IBC channel.
-     * @param le Local end settings for the channel.
-     * @param re Remote end settings for the channel.
-     * @param s Channel handshake settings.
-     * @param expPass Expected pass status of the operation.
-     * If expPass is false, `vm.expectRevert` should be called before this function.
-     */
-    function channelOpenTry(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
-        public
-    {
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ChannelOpenTry(
+            emit OpenIbcChannel(
                 address(le.receiver),
                 le.versionExpected,
                 s.ordering,
                 s.feeEnabled,
                 le.connectionHops,
-                re.portId,
-                re.channelId
+                cp.portId,
+                cp.channelId
             );
         }
-        CounterParty memory cp = CounterParty(re.portId, re.channelId, re.version);
-        dispatcher.channelOpenTry(
+        dispatcher.openIbcChannel(
             le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             s.ordering,
@@ -120,55 +105,31 @@ contract Base is IbcEventsEmitter, ProofBase {
     }
 
     /**
-     * @dev Step-3 of the 4-step handshake to open an IBC channel.
+     * @dev Step-3/4 of the 4-step handshake to open an IBC channel.
      * @param le Local end settings for the channel.
      * @param re Remote end settings for the channel.
      * @param s Channel handshake settings.
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function channelOpenAck(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
-        public
-    {
-        if (expPass) {
-            vm.expectEmit(true, true, true, true);
-            emit ChannelOpenAck(address(le.receiver), le.channelId);
-        }
-        dispatcher.channelOpenAck(
-            le.receiver,
-            CounterParty(le.portId, le.channelId, le.versionCall),
-            le.connectionHops,
-            s.ordering,
-            s.feeEnabled,
-            re,
-            s.proof
-        );
-    }
-
-    /**
-     * @dev Step-4 of the 4-step handshake to open an IBC channel.
-     * @param le Local end settings for the channel.
-     * @param re Remote end settings for the channel.
-     * @param s Channel handshake settings.
-     * @param expPass Expected pass status of the operation.
-     * If expPass is false, `vm.expectRevert` should be called before this function.
-     */
-    function channelOpenConfirm(
+    function connectChannel(
         LocalEnd memory le,
         CounterParty memory re,
         ChannelHandshakeSetting memory s,
+        bool isChannConfirm,
         bool expPass
     ) public {
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ChannelOpenConfirm(address(le.receiver), le.channelId);
+            emit ConnectIbcChannel(address(le.receiver), le.channelId);
         }
-        dispatcher.channelOpenConfirm(
+        dispatcher.connectIbcChannel(
             le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,
             s.feeEnabled,
+            isChannConfirm,
             re,
             s.proof
         );

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -31,38 +31,39 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function test_ibc_channel_open_init() public {
-        vm.expectEmit(true, true, true, true);
-        emit ChannelOpenInit(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId);
+        CounterParty memory counterparty = CounterParty(ch1.portId, bytes32(0), "");
 
+        vm.expectEmit(true, true, true, true);
+        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId, bytes32(0));
         // since this is open chann init, the proof is not used. so use an invalid one
-        dispatcher.channelOpenInit(mars, ch1.version, ChannelOrder.NONE, false, connectionHops1, ch1.portId);
+        dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, counterparty, invalidProof);
     }
 
     function test_ibc_channel_open_try() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_try_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit ChannelOpenTry(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
+        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
 
-        dispatcher.channelOpenTry(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
+        dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
     }
 
     function test_ibc_channel_ack() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_ack_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit ChannelOpenAck(address(mars), ch0.channelId);
+        emit ConnectIbcChannel(address(mars), ch0.channelId);
 
-        dispatcher.channelOpenAck(mars, ch0, connectionHops0, ChannelOrder.NONE, false, ch1, proof);
+        dispatcher.connectIbcChannel(mars, ch0, connectionHops0, ChannelOrder.NONE, false, false, ch1, proof);
     }
 
     function test_ibc_channel_confirm() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit ChannelOpenConfirm(address(mars), ch1.channelId);
+        emit ConnectIbcChannel(address(mars), ch1.channelId);
 
-        dispatcher.channelOpenConfirm(mars, ch1, connectionHops1, ChannelOrder.NONE, false, ch0, proof);
+        dispatcher.connectIbcChannel(mars, ch1, connectionHops1, ChannelOrder.NONE, false, true, ch0, proof);
     }
 
     function test_ack_packet() public {

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -132,10 +132,10 @@ contract VirtualChain is Test, IbcEventsEmitter {
         remoteChain.channelOpenTry(remoteEnd, this, localEnd, setting, true); // step-2
 
         vm.prank(address(this));
-        this.channelOpenConfirm(localEnd, remoteChain, remoteEnd, setting, true); // step-3
+        this.channelOpenAckOrConfirm(localEnd, remoteChain, remoteEnd, setting, false, true); // step-3
 
         vm.prank(address(remoteChain));
-        remoteChain.channelOpenAck(remoteEnd, this, localEnd, setting, true); // step-4
+        remoteChain.channelOpenAckOrConfirm(remoteEnd, this, localEnd, setting, true, true); // step-4
     }
 
     function channelOpenInit(
@@ -153,17 +153,25 @@ contract VirtualChain is Test, IbcEventsEmitter {
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ChannelOpenInit(
+            emit OpenIbcChannel(
                 address(localEnd),
                 setting.version,
                 setting.ordering,
                 setting.feeEnabled,
                 connectionHops,
-                remoteChain.portIds(address(remoteEnd))
+                remoteChain.portIds(address(remoteEnd)),
+                bytes32(0)
             );
         }
-        dispatcher.channelOpenInit(
-            localEnd, setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId
+        dispatcher.openIbcChannel(
+            localEnd,
+            CounterParty(setting.portId, setting.channelId, setting.version),
+            setting.ordering,
+            setting.feeEnabled,
+            connectionHops,
+            // counterparty channelId and version are not known at this point
+            CounterParty(cpPortId, bytes32(0), ""),
+            setting.proof
         );
     }
 
@@ -185,7 +193,7 @@ contract VirtualChain is Test, IbcEventsEmitter {
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ChannelOpenTry(
+            emit OpenIbcChannel(
                 address(localEnd),
                 setting.version,
                 setting.ordering,
@@ -195,7 +203,7 @@ contract VirtualChain is Test, IbcEventsEmitter {
                 cpChanId
             );
         }
-        dispatcher.channelOpenTry(
+        dispatcher.openIbcChannel(
             localEnd,
             CounterParty(setting.portId, setting.channelId, setting.version),
             setting.ordering,
@@ -206,71 +214,38 @@ contract VirtualChain is Test, IbcEventsEmitter {
         );
     }
 
-    function channelOpenAck(
+    function channelOpenAckOrConfirm(
         IbcChannelReceiver localEnd,
         VirtualChain remoteChain,
         IbcChannelReceiver remoteEnd,
         ChannelSetting memory setting,
+        bool isChanConfirm,
         bool expPass
     ) external {
         // local channel Id must be known
         bytes32 chanId = channelIds[address(localEnd)][address(remoteEnd)];
-        require(chanId != bytes32(0), "channelOpenAck: channel does not exist");
+        require(chanId != bytes32(0), "channelOpenAckOrConfirm: channel does not exist");
 
         bytes32 cpChanId = remoteChain.channelIds(address(remoteEnd), address(localEnd));
-        require(cpChanId != bytes32(0), "channelOpenAck: channel does not exist");
+        require(cpChanId != bytes32(0), "channelOpenAckOrConfirm: channel does not exist");
 
         string memory cpPortId = remoteChain.portIds(address(remoteEnd));
-        require(bytes(cpPortId).length > 0, "channelOpenAck: counterparty portId does not exist");
+        require(bytes(cpPortId).length > 0, "channelOpenAckOrConfirm: counterparty portId does not exist");
 
         // set dispatcher's msg.sender to this function's msg.sender
         vm.prank(msg.sender);
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ChannelOpenAck(address(localEnd), chanId);
+            emit ConnectIbcChannel(address(localEnd), chanId);
         }
-        dispatcher.channelOpenAck(
+        dispatcher.connectIbcChannel(
             localEnd,
             CounterParty(setting.portId, chanId, setting.version),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,
-            CounterParty(cpPortId, cpChanId, setting.version),
-            setting.proof
-        );
-    }
-
-    function channelOpenConfirm(
-        IbcChannelReceiver localEnd,
-        VirtualChain remoteChain,
-        IbcChannelReceiver remoteEnd,
-        ChannelSetting memory setting,
-        bool expPass
-    ) external {
-        // local channel Id must be known
-        bytes32 chanId = channelIds[address(localEnd)][address(remoteEnd)];
-        require(chanId != bytes32(0), "channelOpenConfirm: channel does not exist");
-
-        bytes32 cpChanId = remoteChain.channelIds(address(remoteEnd), address(localEnd));
-        require(cpChanId != bytes32(0), "channelOpenConfirm: channel does not exist");
-
-        string memory cpPortId = remoteChain.portIds(address(remoteEnd));
-        require(bytes(cpPortId).length > 0, "channelOpenConfirm: counterparty portId does not exist");
-
-        // set dispatcher's msg.sender to this function's msg.sender
-        vm.prank(msg.sender);
-
-        if (expPass) {
-            vm.expectEmit(true, true, true, true);
-            emit ChannelOpenConfirm(address(localEnd), chanId);
-        }
-        dispatcher.channelOpenConfirm(
-            localEnd,
-            CounterParty(setting.portId, chanId, setting.version),
-            connectionHops,
-            setting.ordering,
-            setting.feeEnabled,
+            isChanConfirm,
             CounterParty(cpPortId, cpChanId, setting.version),
             setting.proof
         );

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -77,10 +77,10 @@ contract UniversalChannelTest is Base {
         eth2.channelOpenTry(ucHandler2, eth1, ucHandler1, setting, true);
 
         vm.prank(unauthorized);
-        eth1.channelOpenAck(ucHandler1, eth2, ucHandler2, setting, true);
+        eth1.channelOpenAckOrConfirm(ucHandler1, eth2, ucHandler2, setting, false, true);
 
         vm.prank(unauthorized);
-        eth2.channelOpenConfirm(ucHandler2, eth1, ucHandler1, setting, true);
+        eth2.channelOpenAckOrConfirm(ucHandler2, eth1, ucHandler1, setting, true, true);
     }
 }
 


### PR DESCRIPTION
Revert channel handshake "split api" changes since those break the api and will make contract
deployment hard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined process for opening and connecting IBC channels with enhanced version compatibility checks.
	- Added new events `OpenIbcChannel` and `ConnectIbcChannel` for better visibility into channel operations.
- **Refactor**
	- Consolidated channel opening functions into `openIbcChannel` and `connectIbcChannel` across multiple contracts for clarity and efficiency.
	- Updated IBC callback functions in the `UniversalChannelHandler` to handle channel openings more effectively.
- **Bug Fixes**
	- Added a new error `VersionMismatch` to handle version incompatibilities during channel connections.
- **Tests**
	- Updated and restructured tests to align with the new channel opening and connection handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->