### PR TITLE
add try/catch to dispatcher

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -87,7 +87,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             revert IBCErrors.invalidCounterPartyPortId();
         }
 
-        if (_isChannelOpenTry(counterparty)) {
+        if (Ibc._isChannelOpenTry(counterparty)) {
             consensusStateManager.verifyMembership(
                 proof,
                 Ibc.channelProofKey(local.portId, local.channelId),
@@ -456,7 +456,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             return false;
         }
         string memory portSuffix = portId[portPrefixLen:];
-        isMatch = _hexStrToAddress(portSuffix) == addr;
+        isMatch = Ibc._hexStrToAddress(portSuffix) == addr;
     }
 
     // Prerequisite: must verify sender is authorized to send packet on the channel
@@ -504,51 +504,5 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             // TODO: check timeoutHeight.revision_number?
             || (packet.timeoutHeight.revision_height != 0 && block.number >= packet.timeoutHeight.revision_height)
         );
-    }
-
-    /**
-     * Convert a non-0x-prefixed hex string to an address
-     * @param hexStr hex string to convert to address. Note that the hex string must not include a 0x prefix.
-     * hexStr is case-insensitive.
-     */
-    function _hexStrToAddress(string memory hexStr) internal pure returns (address addr) {
-        if (bytes(hexStr).length != 40) {
-            revert IBCErrors.invalidHexStringLength();
-        }
-
-        bytes memory strBytes = bytes(hexStr);
-        bytes memory addrBytes = new bytes(20);
-
-        for (uint256 i = 0; i < 20; i++) {
-            uint8 high = uint8(strBytes[i * 2]);
-            uint8 low = uint8(strBytes[1 + i * 2]);
-            // Convert to lowercase if the character is in uppercase
-            if (high >= 65 && high <= 90) {
-                high += 32;
-            }
-            if (low >= 65 && low <= 90) {
-                low += 32;
-            }
-            uint8 digit = (high - (high >= 97 ? 87 : 48)) * 16 + (low - (low >= 97 ? 87 : 48));
-            addrBytes[i] = bytes1(digit);
-        }
-
-        assembly {
-            addr := mload(add(addrBytes, 20))
-        }
-    }
-
-    // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
-    // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
-    function _isChannelOpenTry(CounterParty calldata counterparty) internal pure returns (bool open) {
-        if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
-            open = false;
-            // ChanOpenInit with unknow conterparty
-        } else if (counterparty.channelId != bytes32(0) && bytes(counterparty.version).length != 0) {
-            // this is the ChanOpenTry; counterparty must not be zero-value
-            open = true;
-        } else {
-            revert IBCErrors.invalidCounterParty();
-        }
     }
 }

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -308,7 +308,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             delete sendPacketCommitment[address(receiver)][packet.src.channelId][packet.sequence];
             emit Timeout(address(receiver), packet.src.channelId, packet.sequence);
         } catch {
-            emit TimeOutError(address(receiver));
+            emit TimeoutError(address(receiver));
         }
     }
 

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -96,7 +96,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             );
         }
 
-        (bool success, bytes memory data) = try_catch(
+        (bool success, bytes memory data) = _try_catch(
             address(portAddress),
             abi.encodeWithSelector(
                 IbcChannelReceiver.onOpenIbcChannel.selector,
@@ -157,7 +157,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
         nextSequenceRecv[address(portAddress)][local.channelId] = 1;
         nextSequenceAck[address(portAddress)][local.channelId] = 1;
 
-        (bool success, bytes memory data) = try_catch(
+        (bool success, bytes memory data) = _try_catch(
             address(portAddress),
             abi.encodeWithSelector(
                 IbcChannelReceiver.onConnectIbcChannel.selector,
@@ -185,7 +185,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
         }
 
         IbcChannelReceiver receiver = IbcChannelReceiver(msg.sender);
-        (bool success, bytes memory data) = try_catch(
+        (bool success, bytes memory data) = _try_catch(
             address(receiver),
             abi.encodeWithSelector(
                 IbcChannelReceiver.onCloseIbcChannel.selector,
@@ -294,7 +294,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
             nextSequenceAck[address(receiver)][packet.src.channelId] = packet.sequence + 1;
         }
 
-        (bool success, bytes memory data) = try_catch(
+        (bool success, bytes memory data) = _try_catch(
             address(receiver),
             abi.encodeWithSelector(IbcPacketReceiver.onAcknowledgementPacket.selector, packet, Ibc.parseAckData(ack))
         );
@@ -335,7 +335,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
         }
 
         (bool success, bytes memory data) =
-            try_catch(address(receiver), abi.encodeWithSelector(IbcPacketReceiver.onTimeoutPacket.selector, packet));
+            _try_catch(address(receiver), abi.encodeWithSelector(IbcPacketReceiver.onTimeoutPacket.selector, packet));
         if (success) {
             // delete packet commitment to avoid double timeout
             delete sendPacketCommitment[address(receiver)][packet.src.channelId][packet.sequence];
@@ -399,7 +399,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
         IbcPacket memory pkt = packet;
         AckPacket memory ack;
         (bool success, bytes memory data) =
-            try_catch(address(receiver), abi.encodeWithSelector(IbcPacketReceiver.onRecvPacket.selector, pkt));
+            _try_catch(address(receiver), abi.encodeWithSelector(IbcPacketReceiver.onRecvPacket.selector, pkt));
         if (success) {
             (ack) = abi.decode(data, (AckPacket));
         } else {
@@ -527,7 +527,7 @@ contract Dispatcher is IbcDispatcher, IbcEventsEmitter, Ownable {
     }
 
     // Returns the result of the call if no revert, otherwise returns the error if thrown.
-    function try_catch(address portAddress, bytes memory args) internal returns (bool success, bytes memory message) {
+    function _try_catch(address portAddress, bytes memory args) internal returns (bool success, bytes memory message) {
         if (!Address.isContract(portAddress)) {
             return (false, bytes("call to non-contract"));
         }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -177,8 +177,8 @@ contract RevertingBytesMars is Mars {
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
     function onRecvPacket(IbcPacket memory) external view override onlyIbcDispatcher returns (AckPacket memory ack) {
-        revert OnRecvPacketRevert();
         ack = AckPacket(false, "");
+        revert OnRecvPacketRevert();
     }
 
     function onTimeoutPacket(IbcPacket calldata) external view override onlyIbcDispatcher {

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -132,46 +132,39 @@ contract RevertingStringMars is Mars {
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
     // solhint-disable-next-line
-    function onOpenIbcChannel(
-        string calldata version,
-        ChannelOrder,
-        bool,
-        string[] calldata,
-        CounterParty calldata counterparty
-    ) external view override onlyIbcDispatcher returns (string memory selectedVersion) {
+    function onOpenIbcChannel(string calldata, ChannelOrder, bool, string[] calldata, CounterParty calldata)
+        external
+        view
+        override
+        onlyIbcDispatcher
+        returns (string memory)
+    {
         // solhint-disable-next-line
         require(false, "open ibc channel is reverting");
+        return "";
     }
 
     // solhint-disable-next-line
-    function onRecvPacket(IbcPacket memory packet)
-        external
-        override
-        onlyIbcDispatcher
-        returns (AckPacket memory ackPacket)
-    {
+    function onRecvPacket(IbcPacket memory) external view override onlyIbcDispatcher returns (AckPacket memory ack) {
         // solhint-disable-next-line
         require(false, "on recv packet is reverting");
+        ack = AckPacket(false, "");
     }
 
     // solhint-disable-next-line
-    function onConnectIbcChannel(bytes32 channelId, bytes32, string calldata counterpartyVersion)
-        external
-        override
-        onlyIbcDispatcher
-    {
+    function onConnectIbcChannel(bytes32, bytes32, string calldata) external view override onlyIbcDispatcher {
         // solhint-disable-next-line
         require(false, "connect ibc channel is reverting");
     }
 
     // solhint-disable-next-line
-    function onCloseIbcChannel(bytes32 channelId, string calldata, bytes32) external override onlyIbcDispatcher {
+    function onCloseIbcChannel(bytes32, string calldata, bytes32) external view override onlyIbcDispatcher {
         // solhint-disable-next-line
         require(false, "close ibc channel is reverting");
     }
 
     // solhint-disable-next-line
-    function onAcknowledgementPacket(IbcPacket calldata, AckPacket calldata ack) external override onlyIbcDispatcher {
+    function onAcknowledgementPacket(IbcPacket calldata, AckPacket calldata) external view override onlyIbcDispatcher {
         // solhint-disable-next-line
         require(false, "acknowledgement packet is reverting");
     }
@@ -183,16 +176,12 @@ contract RevertingBytesMars is Mars {
 
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
-    function onRecvPacket(IbcPacket memory packet)
-        external
-        override
-        onlyIbcDispatcher
-        returns (AckPacket memory ackPacket)
-    {
+    function onRecvPacket(IbcPacket memory) external view override onlyIbcDispatcher returns (AckPacket memory ack) {
         revert OnRecvPacketRevert();
+        ack = AckPacket(false, "");
     }
 
-    function onTimeoutPacket(IbcPacket calldata packet) external override onlyIbcDispatcher {
+    function onTimeoutPacket(IbcPacket calldata) external view override onlyIbcDispatcher {
         // solhint-disable-next-line
         revert OnTimeoutPacket();
     }
@@ -201,26 +190,18 @@ contract RevertingBytesMars is Mars {
 contract RevertingEmptyMars is Mars {
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
-    function onRecvPacket(IbcPacket memory packet)
-        external
-        override
-        onlyIbcDispatcher
-        returns (AckPacket memory ackPacket)
-    {
+    function onRecvPacket(IbcPacket memory) external view override onlyIbcDispatcher returns (AckPacket memory ack) {
         // solhint-disable-next-line
         require(false);
+        ack = AckPacket(false, "");
     }
 }
 
 contract PanickingMars is Mars {
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
-    function onRecvPacket(IbcPacket memory packet)
-        external
-        override
-        onlyIbcDispatcher
-        returns (AckPacket memory ackPacket)
-    {
+    function onRecvPacket(IbcPacket memory) external view override onlyIbcDispatcher returns (AckPacket memory ack) {
         assert(false);
+        ack = AckPacket(false, "");
     }
 }

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -64,7 +64,7 @@ interface IbcEventsEmitter {
     event OpenIbcChannelError(address indexed portAddress);
     event CloseIbcChannelError(address indexed receiver);
     event AcknowledgementError(address indexed receiver);
-    event TimeOutError(address indexed receiver);
+    event TimeoutError(address indexed receiver);
 
     //
     // packet events

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -57,14 +57,14 @@ interface IbcEventsEmitter {
     );
 
     event ConnectIbcChannel(address indexed portAddress, bytes32 channelId);
-    event ConnectIbcChannelError(address indexed portAddress);
+    event ConnectIbcChannelError(address indexed portAddress, bytes error);
 
     event CloseIbcChannel(address indexed portAddress, bytes32 indexed channelId);
 
-    event OpenIbcChannelError(address indexed portAddress);
-    event CloseIbcChannelError(address indexed receiver);
-    event AcknowledgementError(address indexed receiver);
-    event TimeoutError(address indexed receiver);
+    event OpenIbcChannelError(address indexed portAddress, bytes error);
+    event CloseIbcChannelError(address indexed receiver, bytes error);
+    event AcknowledgementError(address indexed receiver, bytes error);
+    event TimeoutError(address indexed receiver, bytes error);
 
     //
     // packet events

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -57,8 +57,14 @@ interface IbcEventsEmitter {
     );
 
     event ConnectIbcChannel(address indexed portAddress, bytes32 channelId);
+    event ConnectIbcChannelError(address indexed portAddress);
 
     event CloseIbcChannel(address indexed portAddress, bytes32 indexed channelId);
+
+    event OpenIbcChannelError(address indexed portAddress);
+    event CloseIbcChannelError(address indexed receiver);
+    event AcknowledgementError(address indexed receiver);
+    event TimeOutError(address indexed receiver);
 
     //
     // packet events

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -220,7 +220,7 @@ library IbcUtils {
     }
 }
 
-contract Ibc {
+library Ibc {
     function toStr(bytes32 b) public pure returns (string memory outStr) {
         uint8 i = 0;
         while (i < 32 && b[i] != 0) {

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -221,6 +221,52 @@ library IbcUtils {
 }
 
 library Ibc {
+    /**
+     * Convert a non-0x-prefixed hex string to an address
+     * @param hexStr hex string to convert to address. Note that the hex string must not include a 0x prefix.
+     * hexStr is case-insensitive.
+     */
+    function _hexStrToAddress(string memory hexStr) external pure returns (address addr) {
+        if (bytes(hexStr).length != 40) {
+            revert IBCErrors.invalidHexStringLength();
+        }
+
+        bytes memory strBytes = bytes(hexStr);
+        bytes memory addrBytes = new bytes(20);
+
+        for (uint256 i = 0; i < 20; i++) {
+            uint8 high = uint8(strBytes[i * 2]);
+            uint8 low = uint8(strBytes[1 + i * 2]);
+            // Convert to lowercase if the character is in uppercase
+            if (high >= 65 && high <= 90) {
+                high += 32;
+            }
+            if (low >= 65 && low <= 90) {
+                low += 32;
+            }
+            uint8 digit = (high - (high >= 97 ? 87 : 48)) * 16 + (low - (low >= 97 ? 87 : 48));
+            addrBytes[i] = bytes1(digit);
+        }
+
+        assembly {
+            addr := mload(add(addrBytes, 20))
+        }
+    }
+
+    // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
+    // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
+    function _isChannelOpenTry(CounterParty calldata counterparty) external pure returns (bool open) {
+        if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
+            open = false;
+            // ChanOpenInit with unknow conterparty
+        } else if (counterparty.channelId != bytes32(0) && bytes(counterparty.version).length != 0) {
+            // this is the ChanOpenTry; counterparty must not be zero-value
+            open = true;
+        } else {
+            revert IBCErrors.invalidCounterParty();
+        }
+    }
+
     function toStr(bytes32 b) public pure returns (string memory outStr) {
         uint8 i = 0;
         while (i < 32 && b[i] != 0) {

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -3,15 +3,8 @@ pragma solidity ^0.8.15;
 
 import "../contracts/libs/Ibc.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
-import {
-    Mars,
-    RevertingBytesMars,
-    PanickingMars,
-    RevertingStringMars,
-    RevertingEmptyMars
-} from "../contracts/examples/Mars.sol";
+import {Mars} from "../contracts/examples/Mars.sol";
 import {IbcDispatcher, IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
-import {IbcChannelReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 import "../contracts/core/OpConsensusStateManager.sol";
 import "./Proof.base.t.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -11,6 +11,7 @@ import {
     RevertingEmptyMars
 } from "../contracts/examples/Mars.sol";
 import {IbcDispatcher, IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
+import {IbcChannelReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 import "../contracts/core/OpConsensusStateManager.sol";
 import "./Proof.base.t.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
@@ -19,10 +20,6 @@ using stdStorage for StdStorage;
 
 contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     Mars mars;
-    RevertingBytesMars revertingBytesMars;
-    PanickingMars panickingMars;
-    RevertingEmptyMars revertingEmptyMars;
-    RevertingStringMars revertingStringMars;
     Dispatcher dispatcher;
     OptimisticConsensusStateManager consensusStateManager;
 
@@ -38,10 +35,6 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         consensusStateManager = new OptimisticConsensusStateManager(1, opProofVerifier, l1BlockProvider);
         dispatcher = new Dispatcher("polyibc.eth1.", consensusStateManager);
         mars = new Mars(dispatcher);
-        revertingBytesMars = new RevertingBytesMars(dispatcher);
-        panickingMars = new PanickingMars(dispatcher);
-        revertingEmptyMars = new RevertingEmptyMars(dispatcher);
-        revertingStringMars = new RevertingStringMars(dispatcher);
     }
 
     function test_ibc_channel_open_init() public {
@@ -62,14 +55,6 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
     }
 
-    function test_ibc_channel_open_dapp_revert() public {
-        Ics23Proof memory proof = load_proof("/test/payload/channel_try_pending_proof.hex");
-
-        vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannelError(address(revertingStringMars));
-        dispatcher.openIbcChannel(revertingStringMars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
-    }
-
     function test_ibc_channel_ack() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_ack_pending_proof.hex");
 
@@ -77,15 +62,6 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         emit ConnectIbcChannel(address(mars), ch0.channelId);
 
         dispatcher.connectIbcChannel(mars, ch0, connectionHops0, ChannelOrder.NONE, false, false, ch1, proof);
-    }
-
-    function test_ibc_channel_ack_dapp_revert() public {
-        Ics23Proof memory proof = load_proof("/test/payload/channel_ack_pending_proof.hex");
-        vm.expectEmit(true, true, true, true);
-        emit ConnectIbcChannelError(address(revertingStringMars));
-        dispatcher.connectIbcChannel(
-            revertingStringMars, ch0, connectionHops0, ChannelOrder.NONE, false, false, ch1, proof
-        );
     }
 
     function test_ibc_channel_confirm() public {
@@ -125,35 +101,6 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         dispatcher.acknowledgement(mars, packet, ack, proof);
     }
 
-    function test_ack_packet_dapp_revert() public {
-        Ics23Proof memory proof = load_proof("/test/payload/packet_ack_proof.hex");
-
-        // plant a fake packet commitment so the ack checks go through
-        // use "forge inspect --storage" to find the slot 1
-        bytes32 slot1 = keccak256(abi.encode(address(revertingStringMars), uint32(7))); // current nested mapping slot:
-            // 107
-        bytes32 slot2 = keccak256(abi.encode(ch0.channelId, slot1));
-        bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));
-        vm.store(address(dispatcher), slot3, bytes32(uint256(1)));
-
-        IbcPacket memory packet;
-        packet.data = bytes("packet-1");
-        packet.timeoutTimestamp = 15_566_401_733_896_437_760;
-        packet.src.channelId = ch0.channelId;
-        packet.src.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(revertingStringMars))));
-        packet.dest.portId = ch1.portId;
-        packet.dest.channelId = ch1.channelId;
-        packet.sequence = 1;
-
-        // this data is taken from the write_acknowledgement event emitted by polymer
-        bytes memory ack =
-            bytes('{"result":"eyAiYWNjb3VudCI6ICJhY2NvdW50IiwgInJlcGx5IjogImdvdCB0aGUgbWVzc2FnZSIgfQ=="}');
-
-        vm.expectEmit(true, true, true, true);
-        emit AcknowledgementError(address(revertingStringMars));
-        dispatcher.acknowledgement(revertingStringMars, packet, ack, proof);
-    }
-
     function test_recv_packet() public {
         Ics23Proof memory proof = load_proof("/test/payload/packet_commitment_proof.hex");
 
@@ -175,58 +122,6 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
             AckPacket(true, abi.encodePacked('{ "account": "account", "reply": "got the message" }'))
         );
         dispatcher.recvPacket(mars, packet, proof);
-    }
-
-    function test_recv_packet_callback_revert_and_panic() public {
-        Ics23Proof memory proof = load_proof("/test/payload/packet_commitment_proof.hex");
-
-        // this data is taken from polymerase/tests/e2e/tests/evm.events.test.ts MarsDappPair.createSentPacket()
-        IbcPacket memory packet;
-        packet.data = bytes("packet-1");
-        packet.timeoutTimestamp = 15_566_401_733_896_437_760;
-        packet.dest.channelId = ch1.channelId;
-        packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(revertingBytesMars))));
-        packet.src.portId = ch0.portId;
-        packet.src.channelId = ch0.channelId;
-        packet.sequence = 1;
-
-        // Test Revert Memory
-        vm.expectEmit(true, true, true, true);
-        emit WriteAckPacket(
-            address(revertingBytesMars),
-            packet.dest.channelId,
-            packet.sequence,
-            AckPacket(false, abi.encodeWithSelector(RevertingBytesMars.OnRecvPacketRevert.selector))
-        );
-        dispatcher.recvPacket(revertingBytesMars, packet, proof);
-
-        // Test Revert String
-        packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(revertingStringMars))));
-        vm.expectEmit(true, true, true, true);
-        emit WriteAckPacket(
-            address(revertingStringMars),
-            packet.dest.channelId,
-            packet.sequence,
-            AckPacket(false, bytes("on recv packet is reverting"))
-        );
-        dispatcher.recvPacket(revertingStringMars, packet, proof);
-
-        // Test Revert empty
-        packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(revertingEmptyMars))));
-        vm.expectEmit(true, true, true, true);
-        emit WriteAckPacket(address(revertingEmptyMars), packet.dest.channelId, packet.sequence, AckPacket(false, ""));
-        dispatcher.recvPacket(revertingEmptyMars, packet, proof);
-
-        // Test Panic
-        packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(panickingMars))));
-        vm.expectEmit(true, true, true, true);
-        emit WriteAckPacket(
-            address(panickingMars),
-            packet.dest.channelId,
-            packet.sequence,
-            AckPacket(false, bytes.concat("panic: ", bytes32(uint256(1))))
-        );
-        dispatcher.recvPacket(panickingMars, packet, proof);
     }
 
     function test_timeout_packet() public {

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -193,7 +193,7 @@ contract ChannelHandshakeTest is Base {
 // This Base contract provides an open channel for sub-contract tests
 contract ChannelOpenTestBase is Base {
     string portId = "eth1.7E5F4552091A69125d5DfCb7b8C2659029395Bdf";
-    string portIdI = "eth1.0xd6292A04e605AFf917Bf05b2df5dDdbdc3E35e07";
+    string invalidPortId = "eth1.0xd6292A04e605AFf917Bf05b2df5dDdbdc3E35e07";
     bytes32 channelId = "channel-1";
     address relayer = deriveAddress("relayer");
     bool feeEnabled = false;

--- a/test/Ibc.t.sol
+++ b/test/Ibc.t.sol
@@ -4,17 +4,17 @@ pragma solidity ^0.8.0;
 import "../contracts/libs/Ibc.sol";
 import "forge-std/Test.sol";
 
-contract IbcTest is Ibc, Test {
+contract IbcTest is Test {
     function test_packet_commitment_proof_key() public {
         IbcPacket memory packet =
             IbcPacket(IbcEndpoint("portid", hex"6368616e6e656c2d30"), IbcEndpoint("", 0), 12, hex"", Height(0, 0), 0);
-        assertEq("commitments/ports/portid/channels/channel-0/sequences/12", this.packetCommitmentProofKey(packet));
+        assertEq("commitments/ports/portid/channels/channel-0/sequences/12", Ibc.packetCommitmentProofKey(packet));
     }
 
     function test_packet_ack_proof_key() public {
         IbcPacket memory packet =
             IbcPacket(IbcEndpoint("", 0), IbcEndpoint("portid", hex"6368616e6e656c2d30"), 12, hex"", Height(0, 0), 0);
-        assertEq("acks/ports/portid/channels/channel-0/sequences/12", this.ackProofKey(packet));
+        assertEq("acks/ports/portid/channels/channel-0/sequences/12", Ibc.ackProofKey(packet));
     }
 
     function test_channel_proof_key() public {
@@ -23,7 +23,7 @@ contract IbcTest is Ibc, Test {
 
         assertEq(
             key,
-            this.channelProofKey(
+            Ibc.channelProofKey(
                 "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0")
             )
         );
@@ -34,13 +34,13 @@ contract IbcTest is Ibc, Test {
     }
 
     function test_bytes32_to_string() public {
-        assertEq("channel-0", toStr(bytes32(hex"6368616e6e656c2d30")));
+        assertEq("channel-0", Ibc.toStr(bytes32(hex"6368616e6e656c2d30")));
     }
 
     function test_uint256_to_string() public {
-        assertEq("1", toStr(1));
-        assertEq("112233445566", toStr(112_233_445_566));
-        assertEq("16", toStr(16));
+        assertEq("1", Ibc.toStr(1));
+        assertEq("112233445566", Ibc.toStr(112_233_445_566));
+        assertEq("16", Ibc.toStr(16));
     }
 
     function test_parse_ack() public {
@@ -48,12 +48,12 @@ contract IbcTest is Ibc, Test {
         bytes memory ack =
             bytes('{"result":"eyAiYWNjb3VudCI6ICJhY2NvdW50IiwgInJlcGx5IjogImdvdCB0aGUgbWVzc2FnZSIgfQ=="}');
 
-        AckPacket memory parsed = this.parseAckData(ack);
+        AckPacket memory parsed = Ibc.parseAckData(ack);
         assertTrue(parsed.success);
         assertEq(bytes('{ "account": "account", "reply": "got the message" }'), parsed.data);
 
         bytes memory error = bytes('{"error":"this is an error message"}');
-        AckPacket memory parsederr = this.parseAckData(error);
+        AckPacket memory parsederr = Ibc.parseAckData(error);
         assertFalse(parsederr.success);
         assertEq(bytes("this is an error message"), parsederr.data);
     }

--- a/test/Proof.base.t.sol
+++ b/test/Proof.base.t.sol
@@ -6,7 +6,7 @@ import "../contracts/libs/Ibc.sol";
 import "../contracts/core/OpProofVerifier.sol";
 import {L1Block} from "optimism/L2/L1Block.sol";
 
-contract ProofBase is Test, Ibc {
+contract ProofBase is Test {
     using stdJson for string;
 
     string rootDir = vm.projectRoot();

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -87,10 +87,10 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         );
         this.run_packet_proof_verification(
             input,
-            this.channelProofKey(
+            Ibc.channelProofKey(
                 "polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1")
             ),
-            this.channelProofValue(ChannelState.TRY_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
+            Ibc.channelProofValue(ChannelState.TRY_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
         );
     }
 
@@ -107,10 +107,10 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
             CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "");
         this.run_packet_proof_verification(
             input,
-            this.channelProofKey(
+            Ibc.channelProofKey(
                 "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0")
             ),
-            this.channelProofValue(ChannelState.ACK_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
+            Ibc.channelProofValue(ChannelState.ACK_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
         );
     }
 
@@ -128,10 +128,10 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         );
         this.run_packet_proof_verification(
             input,
-            this.channelProofKey(
+            Ibc.channelProofKey(
                 "polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1")
             ),
-            this.channelProofValue(ChannelState.CONFIRM_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
+            Ibc.channelProofValue(ChannelState.CONFIRM_PENDING, ChannelOrder.NONE, "1.0", connectionHops, counterparty)
         );
     }
 
@@ -149,7 +149,7 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         packet.sequence = 1;
 
         this.run_packet_proof_verification(
-            input, this.packetCommitmentProofKey(packet), abi.encode(this.packetCommitmentProofValue(packet))
+            input, Ibc.packetCommitmentProofKey(packet), abi.encode(Ibc.packetCommitmentProofValue(packet))
         );
     }
 
@@ -169,7 +169,7 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         bytes memory ack =
             bytes('{"result":"eyAiYWNjb3VudCI6ICJhY2NvdW50IiwgInJlcGx5IjogImdvdCB0aGUgbWVzc2FnZSIgfQ=="}');
 
-        this.run_packet_proof_verification(input, this.ackProofKey(packet), abi.encode(this.ackProofValue(ack)));
+        this.run_packet_proof_verification(input, Ibc.ackProofKey(packet), abi.encode(Ibc.ackProofValue(ack)));
     }
 
     // helpers -----------------------------------------------------------------


### PR DESCRIPTION
PR to add try/catch to hopefully mitigate some testnet errors

There wasn't enough space remaining in the contract to add a more sophisticated try/catch that also logs the error thrown by the dapp so I settled for just logging the address of the erroring contract rather than the actual error the dapp threw . I also had to move the Ibc back into a library to reduce the contract size enough to add the simple try/catch.

I decided to leave the sophisticated try/catch around the `.onRecvPacket` callback since _some_ sophisticated error messages are better than none; and I'd imagine more of the errors are happening on that end.

 We still have some more contract space to allow for a few more of the sophisticated try/catch which log the dapp errors thrown; so let me know if there are any callbacks which would benefit from logging the actual error thrown by the dapp 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error events for IBC channel operations in the blockchain contracts.
	- Added `virtual` modifier and new testing contracts with specific behaviors in the `Mars` contract.
	- Enhanced `Ibc` library with new functionalities for address conversion and channel verification.
- **Refactor**
	- Updated the `Dispatcher` contract to use interface references, improved error handling, and adjusted event emissions.
	- Refactored `Ibc` functionalities into a library.
- **Tests**
	- Modified and added new test cases for `Dispatcher` and `Ibc` functionalities, including changes in function names, logic, and variable introductions.
	- Updated test contracts to remove inheritance and utilize static calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->