### PR TITLE
nico/split channel handshake api again

### DIFF
--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -33,7 +33,6 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
         dispatcher.closeIbcChannel(channelId);
     }
 
-    // IBC callback functions
     function onConnectIbcChannel(bytes32 channelId, bytes32, string calldata counterpartyVersion)
         external
         onlyIbcDispatcher
@@ -149,23 +148,28 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
         mwStackAddrs[mwBitmap] = mwAddrs;
     }
 
-    function onOpenIbcChannel(
-        string calldata version,
-        ChannelOrder,
-        bool,
-        string[] calldata,
-        CounterParty calldata counterparty
-    ) external view onlyIbcDispatcher returns (string memory selectedVersion) {
-        if (counterparty.channelId == bytes32(0)) {
-            // ChanOpenInit
-            if (keccak256(abi.encodePacked(version)) != keccak256(abi.encodePacked(VERSION))) {
-                revert UnsupportedVersion();
-            }
-        } else {
-            // ChanOpenTry
-            if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(VERSION))) {
-                revert UnsupportedVersion();
-            }
+    // IBC callback functions
+    function onChanOpenInit(string calldata version)
+        external
+        view
+        onlyIbcDispatcher
+        returns (string memory selectedVersion)
+    {
+        return _openChannel(version);
+    }
+
+    function onChanOpenTry(string calldata counterpartyVersion)
+        external
+        view
+        onlyIbcDispatcher
+        returns (string memory selectedVersion)
+    {
+        return _openChannel(counterpartyVersion);
+    }
+
+    function _openChannel(string calldata version) private pure returns (string memory selectedVersion) {
+        if (keccak256(abi.encodePacked(version)) != keccak256(abi.encodePacked(VERSION))) {
+            revert UnsupportedVersion();
         }
         return VERSION;
     }

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -87,40 +87,33 @@ contract Mars is IbcReceiverBase, IbcReceiver {
         dispatcher.sendPacket(channelId, bytes(message), timeoutTimestamp);
     }
 
-    function onOpenIbcChannel(
-        string calldata version,
-        ChannelOrder,
-        bool,
-        string[] calldata,
-        CounterParty calldata counterparty
-    ) external view virtual onlyIbcDispatcher returns (string memory selectedVersion) {
-        if (bytes(counterparty.portId).length <= 8) {
-            revert IBCErrors.invalidCounterPartyPortId();
-        }
-        /**
-         * Version selection is determined by if the callback is invoked on behalf of ChanOpenInit or ChanOpenTry.
-         * ChanOpenInit: self version should be provided whereas the counterparty version is empty.
-         * ChanOpenTry: counterparty version should be provided whereas the self version is empty.
-         * In both cases, the selected version should be in the supported versions list.
-         */
-        bool foundVersion = false;
-        selectedVersion =
-            keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked("")) ? counterparty.version : version;
-        for (uint256 i = 0; i < supportedVersions.length; i++) {
-            if (keccak256(abi.encodePacked(selectedVersion)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
-                foundVersion = true;
-                break;
-            }
-        }
-        if (!foundVersion) revert UnsupportedVersion();
-        // if counterpartyVersion is not empty, then it must be the same foundVersion
-        if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(""))) {
-            if (keccak256(abi.encodePacked(counterparty.version)) != keccak256(abi.encodePacked(selectedVersion))) {
-                revert VersionMismatch();
-            }
-        }
+    function onChanOpenInit(string calldata version)
+        external
+        view
+        virtual
+        onlyIbcDispatcher
+        returns (string memory selectedVersion)
+    {
+        return _openChannel(version);
+    }
 
-        return selectedVersion;
+    function onChanOpenTry(string calldata counterpartyVersion)
+        external
+        view
+        virtual
+        onlyIbcDispatcher
+        returns (string memory selectedVersion)
+    {
+        return _openChannel(counterpartyVersion);
+    }
+
+    function _openChannel(string calldata version) private view returns (string memory selectedVersion) {
+        for (uint256 i = 0; i < supportedVersions.length; i++) {
+            if (keccak256(abi.encodePacked(version)) == keccak256(abi.encodePacked(supportedVersions[i]))) {
+                return version;
+            }
+        }
+        revert UnsupportedVersion();
     }
 }
 
@@ -132,13 +125,7 @@ contract RevertingStringMars is Mars {
     constructor(IbcDispatcher _dispatcher) Mars(_dispatcher) {}
 
     // solhint-disable-next-line
-    function onOpenIbcChannel(string calldata, ChannelOrder, bool, string[] calldata, CounterParty calldata)
-        external
-        view
-        override
-        onlyIbcDispatcher
-        returns (string memory)
-    {
+    function onChanOpenInit(string calldata) external view override onlyIbcDispatcher returns (string memory) {
         // solhint-disable-next-line
         require(false, "open ibc channel is reverting");
         return "";

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -66,8 +66,11 @@ interface IbcEventsEmitter {
     );
     event ChannelOpenTryError(address indexed receiver, bytes error);
 
-    event ConnectIbcChannel(address indexed portAddress, bytes32 channelId);
-    event ConnectIbcChannelError(address indexed portAddress, bytes error);
+    event ChannelOpenAck(address indexed receiver, bytes32 channelId);
+    event ChannelOpenAckError(address indexed receiver, bytes error);
+
+    event ChannelOpenConfirm(address indexed receiver, bytes32 channelId);
+    event ChannelOpenConfirmError(address indexed receiver, bytes error);
 
     event CloseIbcChannel(address indexed portAddress, bytes32 indexed channelId);
 

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -23,14 +23,13 @@ interface IbcPacketSender {
  *         Other features are implemented as callback methods in the IbcReceiver interface.
  */
 interface IbcDispatcher is IbcPacketSender {
-    function openIbcChannel(
-        IbcChannelReceiver portAddress,
-        CounterParty calldata self,
+    function channelOpenInit(
+        IbcChannelReceiver receiver,
+        string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
-        CounterParty calldata counterparty,
-        Ics23Proof calldata proof
+        string calldata counterpartyPortId
     ) external;
 
     function closeIbcChannel(bytes32 channelId) external;
@@ -46,8 +45,18 @@ interface IbcEventsEmitter {
     //
     // channel events
     //
-    event OpenIbcChannel(
-        address indexed portAddress,
+    event ChannelOpenInit(
+        address indexed recevier,
+        string version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] connectionHops,
+        string counterpartyPortId
+    );
+    event ChannelOpenInitError(address indexed receiver, bytes error);
+
+    event ChannelOpenTry(
+        address indexed receiver,
         string version,
         ChannelOrder ordering,
         bool feeEnabled,
@@ -55,13 +64,13 @@ interface IbcEventsEmitter {
         string counterpartyPortId,
         bytes32 counterpartyChannelId
     );
+    event ChannelOpenTryError(address indexed receiver, bytes error);
 
     event ConnectIbcChannel(address indexed portAddress, bytes32 channelId);
     event ConnectIbcChannelError(address indexed portAddress, bytes error);
 
     event CloseIbcChannel(address indexed portAddress, bytes32 indexed channelId);
 
-    event OpenIbcChannelError(address indexed portAddress, bytes error);
     event CloseIbcChannelError(address indexed receiver, bytes error);
     event AcknowledgementError(address indexed receiver, bytes error);
     event TimeoutError(address indexed receiver, bytes error);

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -16,8 +16,9 @@ interface IbcChannelReceiver {
 
     function onChanOpenTry(string calldata counterpartyVersion) external returns (string memory selectedVersion);
 
-    function onConnectIbcChannel(bytes32 channelId, bytes32 counterpartyChannelId, string calldata counterpartyVersion)
-        external;
+    function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external;
+
+    function onChanOpenConfirm(bytes32 channelId, string calldata counterpartyVersion) external;
 
     function onCloseIbcChannel(bytes32 channelId, string calldata counterpartyPortId, bytes32 counterpartyChannelId)
         external;

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -12,13 +12,9 @@ import {ChannelOrder, CounterParty, IbcPacket, AckPacket} from "../libs/Ibc.sol"
  * handshake callbacks.
  */
 interface IbcChannelReceiver {
-    function onOpenIbcChannel(
-        string calldata version,
-        ChannelOrder ordering,
-        bool feeEnabled,
-        string[] calldata connectionHops,
-        CounterParty calldata counterparty
-    ) external returns (string memory selectedVersion);
+    function onChanOpenInit(string calldata version) external returns (string memory selectedVersion);
+
+    function onChanOpenTry(string calldata counterpartyVersion) external returns (string memory selectedVersion);
 
     function onConnectIbcChannel(bytes32 channelId, bytes32 counterpartyChannelId, string calldata counterpartyVersion)
         external;
@@ -53,7 +49,6 @@ contract IbcReceiverBase is Ownable {
 
     error notIbcDispatcher();
     error UnsupportedVersion();
-    error VersionMismatch();
     error ChannelNotFound();
 
     /**

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -120,31 +120,55 @@ contract Base is IbcEventsEmitter, ProofBase {
     }
 
     /**
-     * @dev Step-3/4 of the 4-step handshake to open an IBC channel.
+     * @dev Step-3 of the 4-step handshake to open an IBC channel.
      * @param le Local end settings for the channel.
      * @param re Remote end settings for the channel.
      * @param s Channel handshake settings.
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function connectChannel(
-        LocalEnd memory le,
-        CounterParty memory re,
-        ChannelHandshakeSetting memory s,
-        bool isChannConfirm,
-        bool expPass
-    ) public {
+    function channelOpenAck(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
+        public
+    {
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ConnectIbcChannel(address(le.receiver), le.channelId);
+            emit ChannelOpenAck(address(le.receiver), le.channelId);
         }
-        dispatcher.connectIbcChannel(
+        dispatcher.channelOpenAck(
             le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,
             s.feeEnabled,
-            isChannConfirm,
+            re,
+            s.proof
+        );
+    }
+
+    /**
+     * @dev Step-4 of the 4-step handshake to open an IBC channel.
+     * @param le Local end settings for the channel.
+     * @param re Remote end settings for the channel.
+     * @param s Channel handshake settings.
+     * @param expPass Expected pass status of the operation.
+     * If expPass is false, `vm.expectRevert` should be called before this function.
+     */
+    function channelOpenConfirm(
+        LocalEnd memory le,
+        CounterParty memory re,
+        ChannelHandshakeSetting memory s,
+        bool expPass
+    ) public {
+        if (expPass) {
+            vm.expectEmit(true, true, true, true);
+            emit ChannelOpenConfirm(address(le.receiver), le.channelId);
+        }
+        dispatcher.channelOpenConfirm(
+            le.receiver,
+            CounterParty(le.portId, le.channelId, le.versionCall),
+            le.connectionHops,
+            s.ordering,
+            s.feeEnabled,
             re,
             s.proof
         );

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -31,21 +31,20 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
     }
 
     function test_ibc_channel_open_init() public {
-        CounterParty memory counterparty = CounterParty(ch1.portId, bytes32(0), "");
-
         vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId, bytes32(0));
+        emit ChannelOpenInit(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId);
+
         // since this is open chann init, the proof is not used. so use an invalid one
-        dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, counterparty, invalidProof);
+        dispatcher.channelOpenInit(mars, ch1.version, ChannelOrder.NONE, false, connectionHops1, ch1.portId);
     }
 
     function test_ibc_channel_open_try() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_try_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannel(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
+        emit ChannelOpenTry(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
 
-        dispatcher.openIbcChannel(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
+        dispatcher.channelOpenTry(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
     }
 
     function test_ibc_channel_ack() public {

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -51,18 +51,18 @@ contract DispatcherIbcWithRealProofs is IbcEventsEmitter, ProofBase {
         Ics23Proof memory proof = load_proof("/test/payload/channel_ack_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit ConnectIbcChannel(address(mars), ch0.channelId);
+        emit ChannelOpenAck(address(mars), ch0.channelId);
 
-        dispatcher.connectIbcChannel(mars, ch0, connectionHops0, ChannelOrder.NONE, false, false, ch1, proof);
+        dispatcher.channelOpenAck(mars, ch0, connectionHops0, ChannelOrder.NONE, false, ch1, proof);
     }
 
     function test_ibc_channel_confirm() public {
         Ics23Proof memory proof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
 
         vm.expectEmit(true, true, true, true);
-        emit ConnectIbcChannel(address(mars), ch1.channelId);
+        emit ChannelOpenConfirm(address(mars), ch1.channelId);
 
-        dispatcher.connectIbcChannel(mars, ch1, connectionHops1, ChannelOrder.NONE, false, true, ch0, proof);
+        dispatcher.channelOpenConfirm(mars, ch1, connectionHops1, ChannelOrder.NONE, false, ch0, proof);
     }
 
     function test_ack_packet() public {

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -33,7 +33,7 @@ contract ChannelHandshakeTest is Base {
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 // remoteEnd has no channelId or version if localEnd is the initiator
-                openChannel(le, re, settings[i], true);
+                channelOpenInit(le, re, settings[i], true);
             }
         }
     }
@@ -50,11 +50,11 @@ contract ChannelHandshakeTest is Base {
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 // remoteEnd version is used
-                openChannel(le, re, settings[i], true);
+                channelOpenInit(le, re, settings[i], true);
 
                 // auto version selection
                 le.versionCall = "";
-                openChannel(le, re, settings[i], true);
+                channelOpenTry(le, re, settings[i], true);
             }
         }
     }
@@ -70,28 +70,9 @@ contract ChannelHandshakeTest is Base {
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 re.version = versions[j];
-                openChannel(le, re, settings[i], true);
+                channelOpenInit(le, re, settings[i], true);
+                channelOpenTry(le, re, settings[i], true);
                 connectChannel(le, re, settings[i], false, true);
-            }
-        }
-    }
-
-    function test_openChannel_receiver_fail_versionMismatch() public {
-        ChannelHandshakeSetting[4] memory settings = createSettings(false, true);
-        string[2] memory versions = ["1.0", "2.0"];
-        for (uint256 i = 0; i < settings.length; i++) {
-            for (uint256 j = 0; j < versions.length; j++) {
-                LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
-                re.version = versions[j];
-                // always select the wrong version
-                bool isVersionOne = keccak256(abi.encodePacked(versions[j])) == keccak256(abi.encodePacked("1.0"));
-                le.versionCall = isVersionOne ? "2.0" : "1.0";
-                vm.expectEmit(true, true, true, true);
-                emit IbcEventsEmitter.OpenIbcChannelError(
-                    address(le.receiver), abi.encodeWithSelector(IbcReceiverBase.VersionMismatch.selector)
-                );
-                openChannel(le, re, settings[i], false);
             }
         }
     }
@@ -106,16 +87,16 @@ contract ChannelHandshakeTest is Base {
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 vm.expectEmit(true, true, true, true);
-                emit IbcEventsEmitter.OpenIbcChannelError(
+                emit IbcEventsEmitter.ChannelOpenInitError(
                     address(le.receiver), abi.encodeWithSelector(IbcReceiverBase.UnsupportedVersion.selector)
                 );
-                openChannel(le, re, settings[i], false);
+                channelOpenInit(le, re, settings[i], false);
             }
         }
     }
 
     function test_openChannel_receiver_fail_invalidProof() public {
-        // When localEnd initiates, no proof verification is done in openIbcChannel
+        // When localEnd initiates, no proof verification is done in channelOpenTry
         ChannelHandshakeSetting[4] memory settings = createSettings(false, false);
         string[1] memory versions = ["1.0"];
         for (uint256 i = 0; i < settings.length; i++) {
@@ -124,8 +105,9 @@ contract ChannelHandshakeTest is Base {
                 CounterParty memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
+
                 vm.expectRevert(DummyConsensusStateManager.InvalidDummyMembershipProof.selector);
-                openChannel(le, re, settings[i], false);
+                channelOpenTry(le, re, settings[i], false);
             }
         }
     }
@@ -139,7 +121,8 @@ contract ChannelHandshakeTest is Base {
                 LocalEnd memory le = _local;
                 CounterParty memory re = _remote;
                 // no remote version applied in openChannel
-                openChannel(le, re, settings[i], true);
+                channelOpenInit(le, re, settings[i], true);
+                channelOpenTry(le, re, settings[i], true);
                 re.version = versions[j];
                 vm.expectEmit(true, true, true, true);
                 emit IbcEventsEmitter.ConnectIbcChannelError(
@@ -159,7 +142,8 @@ contract ChannelHandshakeTest is Base {
                 LocalEnd memory le = _local;
                 CounterParty memory re = _remote;
                 // no remote version applied in openChannel
-                openChannel(le, re, settings[i], true);
+                channelOpenInit(le, re, settings[i], true);
+                channelOpenTry(le, re, settings[i], true);
                 re.version = versions[j];
                 settings[i].proof = invalidProof;
                 vm.expectRevert(DummyConsensusStateManager.InvalidDummyMembershipProof.selector);
@@ -226,8 +210,9 @@ contract ChannelOpenTestBase is Base {
         _localRevertingMars = LocalEnd(revertingBytesMars, portId, channelId, connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
 
-        openChannel(_local, _remote, setting, true);
-        openChannel(_localRevertingMars, _remote, setting, true);
+        channelOpenInit(_local, _remote, setting, true);
+        channelOpenTry(_localRevertingMars, _remote, setting, true);
+
         connectChannel(_local, _remote, setting, false, true);
         connectChannel(_localRevertingMars, _remote, setting, false, true);
     }
@@ -559,17 +544,17 @@ contract DappRevertTests is Base {
     function test_ibc_channel_open_non_dapp_call() public {
         address nonDappAddr = vm.addr(1);
 
-        emit OpenIbcChannelError(nonDappAddr, bytes("call to non-contract"));
-        dispatcher.openIbcChannel(
-            IbcChannelReceiver(nonDappAddr), ch1, ChannelOrder.NONE, false, connectionHops1, ch0, validProof
+        emit ChannelOpenInitError(nonDappAddr, bytes("call to non-contract"));
+        dispatcher.channelOpenInit(
+            IbcChannelReceiver(nonDappAddr), ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
         );
     }
 
     function test_ibc_channel_open_dapp_without_handler() public {
         Earth earth = new Earth(vm.addr(1));
-        emit OpenIbcChannelError(address(earth), "");
-        dispatcher.openIbcChannel(
-            IbcChannelReceiver(address(earth)), ch1, ChannelOrder.NONE, false, connectionHops1, ch0, validProof
+        emit ChannelOpenInitError(address(earth), "");
+        dispatcher.channelOpenInit(
+            IbcChannelReceiver(address(earth)), ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
         );
     }
 
@@ -654,10 +639,12 @@ contract DappRevertTests is Base {
 
     function test_ibc_channel_open_dapp_revert() public {
         vm.expectEmit(true, true, true, true);
-        emit OpenIbcChannelError(
+        emit ChannelOpenInitError(
             address(revertingStringMars), abi.encodeWithSignature("Error(string)", "open ibc channel is reverting")
         );
-        dispatcher.openIbcChannel(revertingStringMars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, validProof);
+        dispatcher.channelOpenInit(
+            revertingStringMars, ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
+        );
     }
 
     function test_ibc_channel_ack_dapp_revert() public {

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -153,25 +153,17 @@ contract VirtualChain is Test, IbcEventsEmitter {
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit OpenIbcChannel(
+            emit ChannelOpenInit(
                 address(localEnd),
                 setting.version,
                 setting.ordering,
                 setting.feeEnabled,
                 connectionHops,
-                remoteChain.portIds(address(remoteEnd)),
-                bytes32(0)
+                remoteChain.portIds(address(remoteEnd))
             );
         }
-        dispatcher.openIbcChannel(
-            localEnd,
-            CounterParty(setting.portId, setting.channelId, setting.version),
-            setting.ordering,
-            setting.feeEnabled,
-            connectionHops,
-            // counterparty channelId and version are not known at this point
-            CounterParty(cpPortId, bytes32(0), ""),
-            setting.proof
+        dispatcher.channelOpenInit(
+            localEnd, setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId
         );
     }
 
@@ -193,7 +185,7 @@ contract VirtualChain is Test, IbcEventsEmitter {
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit OpenIbcChannel(
+            emit ChannelOpenTry(
                 address(localEnd),
                 setting.version,
                 setting.ordering,
@@ -203,7 +195,7 @@ contract VirtualChain is Test, IbcEventsEmitter {
                 cpChanId
             );
         }
-        dispatcher.openIbcChannel(
+        dispatcher.channelOpenTry(
             localEnd,
             CounterParty(setting.portId, setting.channelId, setting.version),
             setting.ordering,

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -132,10 +132,10 @@ contract VirtualChain is Test, IbcEventsEmitter {
         remoteChain.channelOpenTry(remoteEnd, this, localEnd, setting, true); // step-2
 
         vm.prank(address(this));
-        this.channelOpenAckOrConfirm(localEnd, remoteChain, remoteEnd, setting, false, true); // step-3
+        this.channelOpenConfirm(localEnd, remoteChain, remoteEnd, setting, true); // step-3
 
         vm.prank(address(remoteChain));
-        remoteChain.channelOpenAckOrConfirm(remoteEnd, this, localEnd, setting, true, true); // step-4
+        remoteChain.channelOpenAck(remoteEnd, this, localEnd, setting, true); // step-4
     }
 
     function channelOpenInit(
@@ -206,38 +206,71 @@ contract VirtualChain is Test, IbcEventsEmitter {
         );
     }
 
-    function channelOpenAckOrConfirm(
+    function channelOpenAck(
         IbcChannelReceiver localEnd,
         VirtualChain remoteChain,
         IbcChannelReceiver remoteEnd,
         ChannelSetting memory setting,
-        bool isChanConfirm,
         bool expPass
     ) external {
         // local channel Id must be known
         bytes32 chanId = channelIds[address(localEnd)][address(remoteEnd)];
-        require(chanId != bytes32(0), "channelOpenAckOrConfirm: channel does not exist");
+        require(chanId != bytes32(0), "channelOpenAck: channel does not exist");
 
         bytes32 cpChanId = remoteChain.channelIds(address(remoteEnd), address(localEnd));
-        require(cpChanId != bytes32(0), "channelOpenAckOrConfirm: channel does not exist");
+        require(cpChanId != bytes32(0), "channelOpenAck: channel does not exist");
 
         string memory cpPortId = remoteChain.portIds(address(remoteEnd));
-        require(bytes(cpPortId).length > 0, "channelOpenAckOrConfirm: counterparty portId does not exist");
+        require(bytes(cpPortId).length > 0, "channelOpenAck: counterparty portId does not exist");
 
         // set dispatcher's msg.sender to this function's msg.sender
         vm.prank(msg.sender);
 
         if (expPass) {
             vm.expectEmit(true, true, true, true);
-            emit ConnectIbcChannel(address(localEnd), chanId);
+            emit ChannelOpenAck(address(localEnd), chanId);
         }
-        dispatcher.connectIbcChannel(
+        dispatcher.channelOpenAck(
             localEnd,
             CounterParty(setting.portId, chanId, setting.version),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,
-            isChanConfirm,
+            CounterParty(cpPortId, cpChanId, setting.version),
+            setting.proof
+        );
+    }
+
+    function channelOpenConfirm(
+        IbcChannelReceiver localEnd,
+        VirtualChain remoteChain,
+        IbcChannelReceiver remoteEnd,
+        ChannelSetting memory setting,
+        bool expPass
+    ) external {
+        // local channel Id must be known
+        bytes32 chanId = channelIds[address(localEnd)][address(remoteEnd)];
+        require(chanId != bytes32(0), "channelOpenConfirm: channel does not exist");
+
+        bytes32 cpChanId = remoteChain.channelIds(address(remoteEnd), address(localEnd));
+        require(cpChanId != bytes32(0), "channelOpenConfirm: channel does not exist");
+
+        string memory cpPortId = remoteChain.portIds(address(remoteEnd));
+        require(bytes(cpPortId).length > 0, "channelOpenConfirm: counterparty portId does not exist");
+
+        // set dispatcher's msg.sender to this function's msg.sender
+        vm.prank(msg.sender);
+
+        if (expPass) {
+            vm.expectEmit(true, true, true, true);
+            emit ChannelOpenConfirm(address(localEnd), chanId);
+        }
+        dispatcher.channelOpenConfirm(
+            localEnd,
+            CounterParty(setting.portId, chanId, setting.version),
+            connectionHops,
+            setting.ordering,
+            setting.feeEnabled,
             CounterParty(cpPortId, cpChanId, setting.version),
             setting.proof
         );

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -77,10 +77,10 @@ contract UniversalChannelTest is Base {
         eth2.channelOpenTry(ucHandler2, eth1, ucHandler1, setting, true);
 
         vm.prank(unauthorized);
-        eth1.channelOpenAckOrConfirm(ucHandler1, eth2, ucHandler2, setting, false, true);
+        eth1.channelOpenAck(ucHandler1, eth2, ucHandler2, setting, true);
 
         vm.prank(unauthorized);
-        eth2.channelOpenAckOrConfirm(ucHandler2, eth1, ucHandler1, setting, true, true);
+        eth2.channelOpenConfirm(ucHandler2, eth1, ucHandler1, setting, true);
     }
 }
 


### PR DESCRIPTION
This is the same changes introduced by https://github.com/open-ibc/vibc-core-smart-contracts/pull/55 that were later reverted by https://github.com/open-ibc/vibc-core-smart-contracts/pull/62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the structure and naming of functions related to IBC (Inter-Blockchain Communication) channel operations for better clarity and consistency.
- **New Features**
	- Introduced new methods for handling the opening and confirmation of IBC channels.
	- Added new events for tracking the status of IBC channel operations, including tries, acknowledgments, confirmations, and errors.
- **Documentation**
	- Updated interfaces and event names in documentation to reflect changes in IBC channel handling methods and events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->