### PR TITLE
Raunak/multiclient support

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -54,8 +54,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     // keep track of outbound ack packets to prevent replay attack
     mapping(address => mapping(bytes32 => mapping(uint64 => bool))) private _ackPacketCommitment;
     mapping(bytes32 => string) private _channelIdToConnection;
-    mapping(string => uint256) private _connectionToClientId;
-    mapping(uint256 => LightClient) private _clientIdToLightClient;
+    mapping(string => LightClient) private _connectionToLightClient;
     uint256 private _numClients;
 
     //
@@ -88,13 +87,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         OpL2StateProof calldata proof,
         uint256 height,
         uint256 appHash,
-        uint256 clientId
+        string calldata connection
     ) external returns (uint256 fraudProofEndTime, bool ended) {
-        LightClient lightClient = _clientIdToLightClient[clientId];
-        if (address(lightClient) == address(0)) {
-            revert IBCErrors.lightClientNotFound(clientId);
-        }
-        return lightClient.addOpConsensusState(l1header, proof, height, appHash);
+        return _getLightClientFromConnection(connection).addOpConsensusState(l1header, proof, height, appHash);
     }
 
     function setNewConnection(string calldata connection, LightClient lightClient) external onlyOwner {
@@ -102,8 +97,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     }
 
     function removeConnection(string calldata connection) external onlyOwner {
-        uint256 clientId = _connectionToClientId[connection];
-        delete _clientIdToLightClient[clientId];
+        delete _connectionToLightClient[connection];
     }
 
     /**
@@ -581,16 +575,12 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     }
 
     // getOptimisticConsensusState
-    function getOptimisticConsensusState(uint256 height, uint256 clientId)
+    function getOptimisticConsensusState(uint256 height, string calldata connection)
         external
         view
         returns (uint256 appHash, uint256 fraudProofEndTime, bool ended)
     {
-        LightClient lightClient = _clientIdToLightClient[clientId];
-        if (address(lightClient) == address(0)) {
-            revert IBCErrors.lightClientNotFound(clientId);
-        }
-        return lightClient.getState(height);
+        return _getLightClientFromConnection(connection).getState(height);
     }
 
     // verify an EVM address matches an IBC portId.
@@ -610,9 +600,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
             revert IBCErrors.invalidAddress();
         }
 
-        uint256 newClientId = ++_numClients; // Cache clientId to save SLOAD call
-        _connectionToClientId[connection] = newClientId;
-        _clientIdToLightClient[newClientId] = lightClient;
+        _connectionToLightClient[connection] = lightClient;
     }
 
     // Prerequisite: must verify sender is authorized to send packet on the channel
@@ -696,13 +684,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     }
 
     function _getLightClientFromConnection(string memory connection) internal view returns (LightClient lightClient) {
-        uint256 clientId = _connectionToClientId[connection];
-        if (clientId == 0) {
-            revert IBCErrors.invalidConnection(connection);
-        }
-        lightClient = _clientIdToLightClient[clientId];
+        lightClient = _connectionToLightClient[connection];
         if (address(lightClient) == address(0)) {
-            revert IBCErrors.lightClientNotFound(clientId);
+            revert IBCErrors.lightClientNotFound(connection);
         }
     }
 }

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -97,8 +97,13 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         return lightClient.addOpConsensusState(l1header, proof, height, appHash);
     }
 
-    function addNewConnection(string calldata connection, LightClient lightClient) external onlyOwner {
-        _addNewConnection(connection, lightClient);
+    function setNewConnection(string calldata connection, LightClient lightClient) external onlyOwner {
+        _setNewConnection(connection, lightClient);
+    }
+
+    function removeConnection(string calldata connection) external onlyOwner {
+        uint256 clientId = _connectionToClientId[connection];
+        delete _clientIdToLightClient[clientId];
     }
 
     /**
@@ -597,15 +602,12 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         isMatch = Ibc._hexStrToAddress(portId[portPrefixLen:]) == addr;
     }
 
-    function _addNewConnection(string calldata connection, LightClient lightClient) internal {
-        if (address(lightClient) == address(0)) {
-            revert IBCErrors.invalidAddress();
-        }
+    function _setNewConnection(string calldata connection, LightClient lightClient) internal {
         if (bytes(connection).length == 0) {
             revert IBCErrors.invalidConnection("");
         }
-        if (_connectionToClientId[connection] != 0) {
-            revert IBCErrors.invalidConnection(connection);
+        if (address(lightClient) == address(0)) {
+            revert IBCErrors.invalidAddress();
         }
 
         uint256 newClientId = ++_numClients; // Cache clientId to save SLOAD call

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -604,6 +604,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         if (bytes(connection).length == 0) {
             revert IBCErrors.invalidConnection("");
         }
+        if (_connectionToClientId[connection] != 0) {
+            revert IBCErrors.invalidConnection(connection);
+        }
 
         uint256 newClientId = ++_numClients; // Cache clientId to save SLOAD call
         _connectionToClientId[connection] = newClientId;

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -92,10 +92,24 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         return _getLightClientFromConnection(connection).addOpConsensusState(l1header, proof, height, appHash);
     }
 
-    function setNewConnection(string calldata connection, LightClient lightClient) external onlyOwner {
-        _setNewConnection(connection, lightClient);
+    /**
+     * @notice Sets the specified `LightClient` for the given connection
+     * @notice Can either be used to either set a new client for a new connection, or to update an existing connection's
+     * client.
+     * @dev Only callable by the contract owner.
+     * @param connection The connection string identifying the connection.
+     * @param lightClient The address of the `LightClient` contract to be set.
+     */
+    function setClientForConnection(string calldata connection, LightClient lightClient) external onlyOwner {
+        _setClientForConnection(connection, lightClient);
     }
 
+    /**
+     * @notice Remove's the given connection's light client.
+     * @notice The conneciton will be unuseable after this operation until the client is set again.
+     * @dev Only callable by the contract owner.
+     * @param connection The connection string to remove the light client from.
+     */
     function removeConnection(string calldata connection) external onlyOwner {
         delete _connectionToLightClient[connection];
     }
@@ -592,7 +606,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         isMatch = Ibc._hexStrToAddress(portId[portPrefixLen:]) == addr;
     }
 
-    function _setNewConnection(string calldata connection, LightClient lightClient) internal {
+    function _setClientForConnection(string calldata connection, LightClient lightClient) internal {
         if (bytes(connection).length == 0) {
             revert IBCErrors.invalidConnection("");
         }

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -43,7 +43,7 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
         string calldata counterpartyPortId
     ) external;
 
-    function addNewConnection(string calldata connection, LightClient lightClient) external;
+    function setNewConnection(string calldata connection, LightClient lightClient) external;
 
     /**
      * This function is called by a 'relayer' on behalf of a dApp. The dApp should implement IbcChannelHandler's

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -43,7 +43,7 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
         string calldata counterpartyPortId
     ) external;
 
-    function setNewConnection(string calldata connection, LightClient lightClient) external;
+    function setClientForConnection(string calldata connection, LightClient lightClient) external;
 
     function removeConnection(string calldata connection) external;
 

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -45,6 +45,8 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
 
     function setNewConnection(string calldata connection, LightClient lightClient) external;
 
+    function removeConnection(string calldata connection) external;
+
     /**
      * This function is called by a 'relayer' on behalf of a dApp. The dApp should implement IbcChannelHandler's
      * onChanOpenTry. If the callback succeeds, the dApp should return the selected version and the emitted event

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -16,6 +16,7 @@ import {
     IbcUtils,
     Ibc
 } from "../libs/Ibc.sol";
+import {LightClient} from "./LightClient.sol";
 
 interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
     function setPortPrefix(string calldata _portPrefix) external;
@@ -24,7 +25,8 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
         L1Header calldata l1header,
         OpL2StateProof calldata proof,
         uint256 height,
-        uint256 appHash
+        uint256 appHash,
+        uint256 clientId
     ) external returns (uint256 fraudProofEndTime, bool ended);
 
     /**
@@ -40,6 +42,8 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
         string[] calldata connectionHops,
         string calldata counterpartyPortId
     ) external;
+
+    function addNewConnection(string calldata connection, LightClient lightClient) external;
 
     /**
      * This function is called by a 'relayer' on behalf of a dApp. The dApp should implement IbcChannelHandler's
@@ -99,7 +103,7 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
 
     function recvPacket(IbcPacketReceiver receiver, IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
-    function getOptimisticConsensusState(uint256 height)
+    function getOptimisticConsensusState(uint256 height, uint256 clientId)
         external
         view
         returns (uint256 appHash, uint256 fraudProofEndTime, bool ended);

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -26,7 +26,7 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
         OpL2StateProof calldata proof,
         uint256 height,
         uint256 appHash,
-        uint256 clientId
+        string calldata connection
     ) external returns (uint256 fraudProofEndTime, bool ended);
 
     /**
@@ -105,7 +105,7 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
 
     function recvPacket(IbcPacketReceiver receiver, IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
-    function getOptimisticConsensusState(uint256 height, uint256 clientId)
+    function getOptimisticConsensusState(uint256 height, string calldata connection)
         external
         view
         returns (uint256 appHash, uint256 fraudProofEndTime, bool ended);

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -168,7 +168,7 @@ library IBCErrors {
     error invalidChannelType(string channelType);
 
     // related to clients
-    error lightClientNotFound(uint256 lightClientId);
+    error lightClientNotFound(string connection);
     error channelIdNotFound(bytes32 channelId);
     error invalidConnection(string connection);
 }

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -169,10 +169,8 @@ library IBCErrors {
 
     // related to clients
     error lightClientNotFound(uint256 lightClientId);
-    error connectionToClientId(string connection);
     error channelIdNotFound(bytes32 channelId);
     error invalidConnection(string connection);
-    error constructorArrayMismatch(uint256 connectionLength, uint256 lightClientLength);
 }
 
 // define a library of Ibc utility functions

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -166,6 +166,13 @@ library IBCErrors {
     error receiverNotOriginPacketSender();
 
     error invalidChannelType(string channelType);
+
+    // related to clients
+    error lightClientNotFound(uint256 lightClientId);
+    error connectionToClientId(string connection);
+    error channelIdNotFound(bytes32 channelId);
+    error invalidConnection(string connection);
+    error constructorArrayMismatch(uint256 connectionLength, uint256 lightClientLength);
 }
 
 // define a library of Ibc utility functions

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -34,6 +34,7 @@ struct ChannelHandshakeSetting {
 // Base contract for testing Dispatcher
 contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     uint32 CONNECTION_TO_CLIENT_ID_STARTING_SLOT = 111;
+    uint32 SEND_PACKET_COMMITMENT_STARTING_SLOT = 107;
     uint64 UINT64_MAX = 18_446_744_073_709_551_615;
 
     Height ZERO_HEIGHT = Height(0, 0);
@@ -194,6 +195,18 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     function _storeChannelidToConnectionMapping(bytes32 channelId, bytes32 connection) internal {
         bytes32 chanIdToConnectionMapping = keccak256(abi.encode(channelId, uint32(110)));
         vm.store(address(dispatcherProxy), chanIdToConnectionMapping, connection);
+    }
+
+    // Plant a fake packet commitment so the ack checks go through
+    // Stdstore doesn't work for proxies so we have to use store
+    // use "forge inspect Dispatcher storage" to find the nested mapping slot
+    function _storeSendPacketCommitment(address receiver, bytes32 channelId, uint64 sequence, uint64 commitment)
+        internal
+    {
+        bytes32 slot1 = keccak256(abi.encode(receiver, uint32(SEND_PACKET_COMMITMENT_STARTING_SLOT)));
+        bytes32 slot2 = keccak256(abi.encode(channelId, slot1));
+        bytes32 slot3 = keccak256(abi.encode(sequence, slot2));
+        vm.store(address(dispatcherProxy), slot3, bytes32(uint256(commitment)));
     }
 
     // Store connection in channelid to connection mapping using store

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -39,8 +39,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     uint64 maxTimeout = UINT64_MAX;
 
     LightClient opLightClient = new OptimisticLightClient(1800, opProofVerifier, l1BlockProvider);
-
-    LightClient dummyConsStateManager = new DummyLightClient();
+    LightClient dummyLightClient = new DummyLightClient();
 
     IDispatcher public dispatcherProxy;
     Dispatcher public dispatcherImplementation;

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -33,6 +33,7 @@ struct ChannelHandshakeSetting {
 
 // Base contract for testing Dispatcher
 contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
+    uint32 CONNECTION_TO_CLIENT_ID_STARTING_SLOT = 111;
     uint64 UINT64_MAX = 18_446_744_073_709_551_615;
 
     Height ZERO_HEIGHT = Height(0, 0);
@@ -193,5 +194,11 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     function _storeChannelidToConnectionMapping(bytes32 channelId, bytes32 connection) internal {
         bytes32 chanIdToConnectionMapping = keccak256(abi.encode(channelId, uint32(110)));
         vm.store(address(dispatcherProxy), chanIdToConnectionMapping, connection);
+    }
+
+    // Store connection in channelid to connection mapping using store
+    function _getConnectiontoClientIdMapping(string memory connection) internal returns (uint256 clientId) {
+        bytes32 clientIdSlot = keccak256(abi.encode(connection, CONNECTION_TO_CLIENT_ID_STARTING_SLOT));
+        clientId = uint256(vm.load(address(dispatcherProxy), clientIdSlot));
     }
 }

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -189,4 +189,10 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             ? abi.encodePacked('{"result":"', Base64.encode(ack.data), '"}')
             : abi.encodePacked('{"error":"', ack.data, '"}');
     }
+
+    // Store connection in channelid to connection mapping using store
+    function _storeChannelidToConnectionMapping(bytes32 channelId, bytes32 connection) internal {
+        bytes32 chanIdToConnectionMapping = keccak256(abi.encode(channelId, uint32(110)));
+        vm.store(address(dispatcherProxy), chanIdToConnectionMapping, connection);
+    }
 }

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -15,13 +15,17 @@ abstract contract DispatcherUpdateClientTestSuite is Base {
     function test_updateOptimisticConsensusState_success() public {
         // trick the L1Block contract into thinking it is updated with the right l1 header
         setL1BlockAttributes(keccak256(RLPWriter.writeList(l1header.header)), l1header.number);
-        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, validStateProof, 1, uint256(apphash), 1);
+        dispatcherProxy.updateClientWithOptimisticConsensusState(
+            l1header, validStateProof, 1, uint256(apphash), "connection-0"
+        );
     }
 
     function test_updateOptimisticConsensusState_failure() public {
         setL1BlockAttributes(keccak256(RLPWriter.writeList(l1header.header)), l1header.number);
         vm.expectRevert("MerkleTrie: ran out of proof elements");
-        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, invalidStateProof, 1, uint256(apphash), 1);
+        dispatcherProxy.updateClientWithOptimisticConsensusState(
+            l1header, invalidStateProof, 1, uint256(apphash), "connection-0"
+        );
     }
 }
 

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -15,18 +15,19 @@ abstract contract DispatcherUpdateClientTestSuite is Base {
     function test_updateOptimisticConsensusState_success() public {
         // trick the L1Block contract into thinking it is updated with the right l1 header
         setL1BlockAttributes(keccak256(RLPWriter.writeList(l1header.header)), l1header.number);
-        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, validStateProof, 1, uint256(apphash));
+        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, validStateProof, 1, uint256(apphash), 1);
     }
 
     function test_updateOptimisticConsensusState_failure() public {
         setL1BlockAttributes(keccak256(RLPWriter.writeList(l1header.header)), l1header.number);
         vm.expectRevert("MerkleTrie: ran out of proof elements");
-        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, invalidStateProof, 1, uint256(apphash));
+        dispatcherProxy.updateClientWithOptimisticConsensusState(l1header, invalidStateProof, 1, uint256(apphash), 1);
     }
 }
 
 contract DispatcherUpdateClientTest is DispatcherUpdateClientTestSuite {
     function setUp() public virtual override {
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, opLightClient);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection("connection-0", opLightClient);
     }
 }

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -32,6 +32,6 @@ abstract contract DispatcherUpdateClientTestSuite is Base {
 contract DispatcherUpdateClientTest is DispatcherUpdateClientTestSuite {
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection("connection-0", opLightClient);
+        dispatcherProxy.setClientForConnection("connection-0", opLightClient);
     }
 }

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -28,6 +28,6 @@ abstract contract DispatcherUpdateClientTestSuite is Base {
 contract DispatcherUpdateClientTest is DispatcherUpdateClientTestSuite {
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection("connection-0", opLightClient);
+        dispatcherProxy.setNewConnection("connection-0", opLightClient);
     }
 }

--- a/test/Dispatcher.multiclient.sol
+++ b/test/Dispatcher.multiclient.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.15;
+
+import "../contracts/libs/Ibc.sol";
+import {Mars} from "../contracts/examples/Mars.sol";
+import {DispatcherProofTestUtils} from "./Dispatcher.proof.t.sol";
+import {DummyLightClient} from "../contracts/utils/DummyLightClient.sol";
+import {OptimisticLightClient} from "../contracts/core/OpLightClient.sol";
+import "../contracts/interfaces/ProofVerifier.sol";
+
+contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
+    string[] connectionHops0 = ["dummy-connection-1", "dummy-connection-2"];
+    string[] connectionHops1 = ["connection-2", "connection-1"];
+    // string[] connectionHops1 = ["op-connection-1", "op-connection-2"];
+    Mars mars;
+    address notOwner = vm.addr(1);
+    CounterParty ch0 =
+        CounterParty("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
+    CounterParty ch1 =
+        CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
+
+    function setUp() public override {
+        opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
+        dummyLightClient = new DummyLightClient();
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
+        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.addNewConnection(connectionHops1[0], opLightClient);
+        mars = new Mars(dispatcherProxy);
+    }
+
+    function test_channelOpenTry_multiClient() public {
+        Ics23Proof memory dummyProof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
+
+        // We should be able to open any connection through the dummy light client
+        // Should be able to open a channel easily through the dummy light client
+        vm.expectEmit(true, true, true, true);
+        emit ChannelOpenTry(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops0, ch1.portId, ch1.channelId);
+        dispatcherProxy.channelOpenTry(mars, ch0, ChannelOrder.NONE, false, connectionHops0, ch1, dummyProof);
+
+        // Having a dummy light client shouldn't impact opLightClient's ability to reject invalid proofs
+        vm.expectRevert(abi.encodeWithSelector(ProofVerifier.InvalidProofValue.selector));
+        dispatcherProxy.channelOpenTry(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, dummyProof);
+    }
+
+    function test_sendPacket_multiClient() public {
+        Ics23Proof memory openChannelProof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
+        Ics23Proof memory invalidProof = load_proof("/test/payload/packet_ack_proof.hex");
+
+        // Set up valid connections from both dummy and real clients
+        dispatcherProxy.channelOpenConfirm(mars, ch0, connectionHops0, ChannelOrder.NONE, false, ch1, invalidProof);
+        dispatcherProxy.channelOpenConfirm(mars, ch1, connectionHops1, ChannelOrder.NONE, false, ch0, openChannelProof);
+
+        // dispatcherproxy.sendpacket should revert using channel 1
+        IbcEndpoint memory src = IbcEndpoint(IbcUtils.addressToPortId("polyibc.eth1.", address(mars)), ch1.channelId);
+        IbcEndpoint memory dest = IbcEndpoint(ch0.portId, ch0.channelId);
+
+        IbcPacket memory packet = IbcPacket(src, dest, uint64(1), bytes("sendPacket"), Height(0, 0), 0);
+
+        // OpProofverifier will cause acknowledgement to fail
+        vm.expectRevert(abi.encodeWithSelector(ProofVerifier.InvalidProofKey.selector));
+        dispatcherProxy.acknowledgement(mars, packet, bytes("ack"), invalidProof);
+    }
+
+    function test_Dispatcher_Prevenrts_nonOwner_AddConnection() public {
+        vm.startPrank(notOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        dispatcherProxy.addNewConnection("malicious-connection-1", opLightClient);
+    }
+
+    function test_duplicate_channels_cannot_be_added() public {
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidConnection.selector, connectionHops0[0]));
+        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
+    }
+}

--- a/test/Dispatcher.multiclient.sol
+++ b/test/Dispatcher.multiclient.sol
@@ -62,14 +62,25 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
         dispatcherProxy.acknowledgement(mars, packet, bytes("ack"), invalidProof);
     }
 
-    function test_Dispatcher_Prevenrts_nonOwner_AddConnection() public {
+    function test_Dispatcher_Prevents_nonOwner_SetConnection() public {
         vm.startPrank(notOwner);
         vm.expectRevert("Ownable: caller is not the owner");
         dispatcherProxy.setNewConnection("malicious-connection-1", opLightClient);
     }
 
+    function test_Dispatcher_Prevents_nonOwner_RemoveConnection() public {
+        vm.startPrank(notOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
+        dispatcherProxy.removeConnection(connectionHops0[0]);
+    }
+
     function test_addr0_channels_cannot_be_added() public {
         vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidAddress.selector));
         dispatcherProxy.setNewConnection(connectionHops0[0], LightClient(address(0)));
+    }
+
+    function test_Dispatcher_removeConnection() public {
+        dispatcherProxy.removeConnection(connectionHops0[0]);
+        assertEq(_getConnectiontoClientIdMapping(connectionHops0[0]), 0);
     }
 }

--- a/test/Dispatcher.multiclient.sol
+++ b/test/Dispatcher.multiclient.sol
@@ -6,6 +6,7 @@ import {Mars} from "../contracts/examples/Mars.sol";
 import {DispatcherProofTestUtils} from "./Dispatcher.proof.t.sol";
 import {DummyLightClient} from "../contracts/utils/DummyLightClient.sol";
 import {OptimisticLightClient} from "../contracts/core/OpLightClient.sol";
+import {LightClient} from "../contracts/interfaces/LightClient.sol";
 import "../contracts/interfaces/ProofVerifier.sol";
 
 contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
@@ -23,8 +24,8 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
         opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         dummyLightClient = new DummyLightClient();
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
-        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
-        dispatcherProxy.addNewConnection(connectionHops1[0], opLightClient);
+        dispatcherProxy.setNewConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops1[0], opLightClient);
         mars = new Mars(dispatcherProxy);
     }
 
@@ -64,11 +65,11 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
     function test_Dispatcher_Prevenrts_nonOwner_AddConnection() public {
         vm.startPrank(notOwner);
         vm.expectRevert("Ownable: caller is not the owner");
-        dispatcherProxy.addNewConnection("malicious-connection-1", opLightClient);
+        dispatcherProxy.setNewConnection("malicious-connection-1", opLightClient);
     }
 
-    function test_duplicate_channels_cannot_be_added() public {
-        vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidConnection.selector, connectionHops0[0]));
-        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
+    function test_addr0_channels_cannot_be_added() public {
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidAddress.selector));
+        dispatcherProxy.setNewConnection(connectionHops0[0], LightClient(address(0)));
     }
 }

--- a/test/Dispatcher.multiclient.sol
+++ b/test/Dispatcher.multiclient.sol
@@ -24,8 +24,8 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
         opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         dummyLightClient = new DummyLightClient();
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
-        dispatcherProxy.setNewConnection(connectionHops0[0], dummyLightClient);
-        dispatcherProxy.setNewConnection(connectionHops1[0], opLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops1[0], opLightClient);
         mars = new Mars(dispatcherProxy);
     }
 
@@ -64,14 +64,14 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
         dispatcherProxy.acknowledgement(mars, packet, ackData, invalidProof);
 
         // Now we change the client to the dummy client and the packet should go through since it circumvents the proof
-        dispatcherProxy.setNewConnection(connectionHops1[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops1[0], dummyLightClient);
         dispatcherProxy.acknowledgement(mars, packet, ackData, invalidProof);
     }
 
     function test_Dispatcher_Prevents_nonOwner_SetConnection() public {
         vm.startPrank(notOwner);
         vm.expectRevert("Ownable: caller is not the owner");
-        dispatcherProxy.setNewConnection("malicious-connection-1", opLightClient);
+        dispatcherProxy.setClientForConnection("malicious-connection-1", opLightClient);
     }
 
     function test_Dispatcher_Prevents_nonOwner_RemoveConnection() public {
@@ -82,7 +82,7 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
 
     function test_addr0_channels_cannot_be_added() public {
         vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidAddress.selector));
-        dispatcherProxy.setNewConnection(connectionHops0[0], LightClient(address(0)));
+        dispatcherProxy.setClientForConnection(connectionHops0[0], LightClient(address(0)));
     }
 
     function test_Dispatcher_removeConnection() public {

--- a/test/Dispatcher.multiclient.sol
+++ b/test/Dispatcher.multiclient.sol
@@ -56,10 +56,16 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
         IbcEndpoint memory dest = IbcEndpoint(ch0.portId, ch0.channelId);
 
         IbcPacket memory packet = IbcPacket(src, dest, uint64(1), bytes("sendPacket"), Height(0, 0), 0);
+        _storeSendPacketCommitment(address(mars), packet.src.channelId, 1, 1);
+        bytes memory ackData = bytes.concat(keccak256(hex"22726573756c7422"));
 
         // OpProofverifier will cause acknowledgement to fail
         vm.expectRevert(abi.encodeWithSelector(ProofVerifier.InvalidProofKey.selector));
-        dispatcherProxy.acknowledgement(mars, packet, bytes("ack"), invalidProof);
+        dispatcherProxy.acknowledgement(mars, packet, ackData, invalidProof);
+
+        // Now we change the client to the dummy client and the packet should go through since it circumvents the proof
+        dispatcherProxy.setNewConnection(connectionHops1[0], dummyLightClient);
+        dispatcherProxy.acknowledgement(mars, packet, ackData, invalidProof);
     }
 
     function test_Dispatcher_Prevents_nonOwner_SetConnection() public {
@@ -80,7 +86,19 @@ contract DispatcherRealProofMultiClient is DispatcherProofTestUtils {
     }
 
     function test_Dispatcher_removeConnection() public {
-        dispatcherProxy.removeConnection(connectionHops0[0]);
-        assertEq(_getConnectiontoClientIdMapping(connectionHops0[0]), 0);
+        Ics23Proof memory openChannelProof = load_proof("/test/payload/channel_confirm_pending_proof.hex");
+
+        // Set up valid connection from channel 1
+        dispatcherProxy.channelOpenConfirm(mars, ch1, connectionHops1, ChannelOrder.NONE, false, ch0, openChannelProof);
+        IbcEndpoint memory src = IbcEndpoint(IbcUtils.addressToPortId("polyibc.eth1.", address(mars)), ch1.channelId);
+        IbcEndpoint memory dest = IbcEndpoint(ch0.portId, ch0.channelId);
+        IbcPacket memory packet = IbcPacket(src, dest, uint64(1), bytes("sendPacket"), Height(0, 0), 0);
+
+        // Remove connection to ensure packet can't be acked after removing light client
+        dispatcherProxy.removeConnection(connectionHops1[0]);
+        assertEq(_getConnectiontoClientIdMapping(connectionHops1[0]), 0);
+
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.lightClientNotFound.selector, connectionHops1[0]));
+        dispatcherProxy.acknowledgement(mars, packet, bytes("ack"), openChannelProof);
     }
 }

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -133,6 +133,8 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Dispatch
     }
 
     function test_timeout_packet_revert() public {
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d310000000000000000000000000000000000000018); // Connection-1
+        _storeChannelidToConnectionMapping(ch1.channelId, connectionStr);
         // Timeout reverts since it is not yet implemented
         Ics23Proof memory proof = load_proof("/test/payload/packet_commitment_proof.hex");
         IbcPacket memory packet;
@@ -141,7 +143,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Dispatch
         packet.dest.channelId = ch1.channelId;
         packet.dest.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(mars))));
         packet.src.portId = string(abi.encodePacked("polyibc.eth1.", IbcUtils.toHexStr(address(mars))));
-        packet.src.channelId = ch0.channelId;
+        packet.src.channelId = ch1.channelId;
         packet.sequence = 1;
 
         vm.expectRevert(abi.encodeWithSelector(ProofVerifier.MethodNotImplemented.selector));

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -70,6 +70,10 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));
         vm.store(address(dispatcherProxy), slot3, bytes32(uint256(1)));
 
+        // store connection in channelid to connection
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d300000000000000000000000000000000000000018); // Connection-0
+        _storeChannelidToConnectionMapping(ch0.channelId, connectionStr);
+
         IbcPacket memory packet;
         packet.data = bytes("packet-1");
         packet.timeoutTimestamp = 15_566_401_733_896_437_760;
@@ -91,6 +95,9 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
 
     function test_recv_packet() public {
         Ics23Proof memory proof = load_proof("/test/payload/packet_commitment_proof.hex");
+        // store connection in channelid to connection
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d300000000000000000000000000000000000000018); // Connection-0
+        _storeChannelidToConnectionMapping(ch1.channelId, connectionStr);
 
         // this data is taken from polymerase/tests/e2e/tests/evm.events.test.ts MarsDappPair.createSentPacket()
         IbcPacket memory packet;
@@ -147,8 +154,11 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
     function setUp() public override {
         super.setUp();
         consensusStateManager = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
-        (dispatcherProxy, dispatcherImplementation) =
-            deployDispatcherProxyAndImpl("polyibc.eth1.", consensusStateManager);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
+        dispatcherProxy.addNewConnection(connectionHops0[0], consensusStateManager);
+        dispatcherProxy.addNewConnection(connectionHops0[1], consensusStateManager);
+        dispatcherProxy.addNewConnection(connectionHops1[0], consensusStateManager);
+        dispatcherProxy.addNewConnection(connectionHops1[1], consensusStateManager);
         mars = new Mars(dispatcherProxy);
     }
 }

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -81,13 +81,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Dispatch
     function test_ack_packet() public {
         Ics23Proof memory proof = load_proof("/test/payload/packet_ack_proof.hex");
 
-        // Plant a fake packet commitment so the ack checks go through
-        // Stdstore doesn't work for proxies so we have to use store
-        // use "forge inspect Dispatcher storage" to find the nested mapping slot
-        bytes32 slot1 = keccak256(abi.encode(address(mars), uint32(107)));
-        bytes32 slot2 = keccak256(abi.encode(ch0.channelId, slot1));
-        bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));
-        vm.store(address(dispatcherProxy), slot3, bytes32(uint256(1)));
+        _storeSendPacketCommitment(address(mars), ch0.channelId, 1, 1);
 
         // store connection in channelid to connection
         bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d300000000000000000000000000000000000000018); // Connection-0

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -10,12 +10,31 @@ import {IbcDispatcher, IbcEventsEmitter} from "../contracts/interfaces/IbcDispat
 import "../contracts/core/OpLightClient.sol";
 import "./Proof.base.t.sol";
 import {stdStorage, StdStorage} from "forge-std/Test.sol";
+import {ChannelHandshakeSetting} from "./Dispatcher.base.t.sol";
+import {DummyLightClient} from "../contracts/utils/DummyLightClient.sol";
+import {DispatcherSendPacketTestSuite, ChannelOpenTestBaseSetup} from "./Dispatcher.t.sol";
 
-abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
+contract DispatcherProofTestUtils is Base {
     using stdStorage for StdStorage;
 
+    function load_proof(string memory filepath) internal returns (Ics23Proof memory) {
+        (bytes32 apphash, Ics23Proof memory proof) =
+            abi.decode(vm.parseBytes(vm.readFile(string.concat(rootDir, filepath))), (bytes32, Ics23Proof));
+
+        // this loads the app hash we got from the testing data into the consensus state manager internals
+        // at the height it's supposed to go. That is, a block less than where the proof was generated from.
+        stdstore.target(address(opLightClient)).sig("consensusStates(uint256)").with_key(proof.height - 1).checked_write(
+            apphash
+        );
+        // trick the fraud time window check
+        vm.warp(block.timestamp + 1);
+
+        return proof;
+    }
+}
+
+abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, DispatcherProofTestUtils {
     Mars mars;
-    OptimisticLightClient consensusStateManager;
 
     CounterParty ch0 =
         CounterParty("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
@@ -134,31 +153,17 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         vm.expectRevert(abi.encodeWithSelector(ProofVerifier.MethodNotImplemented.selector));
         dispatcherProxy.timeout(mars, packet, proof);
     }
-
-    function load_proof(string memory filepath) internal returns (Ics23Proof memory) {
-        (bytes32 apphash, Ics23Proof memory proof) =
-            abi.decode(vm.parseBytes(vm.readFile(string.concat(rootDir, filepath))), (bytes32, Ics23Proof));
-
-        // this loads the app hash we got from the testing data into the consensus state manager internals
-        // at the height it's supposed to go. That is, a block less than where the proof was generated from.
-        stdstore.target(address(consensusStateManager)).sig("consensusStates(uint256)").with_key(proof.height - 1)
-            .checked_write(apphash);
-        // trick the fraud time window check
-        vm.warp(block.timestamp + 1);
-
-        return proof;
-    }
 }
 
 contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
     function setUp() public override {
         super.setUp();
-        consensusStateManager = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
+        opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
-        dispatcherProxy.addNewConnection(connectionHops0[0], consensusStateManager);
-        dispatcherProxy.addNewConnection(connectionHops0[1], consensusStateManager);
-        dispatcherProxy.addNewConnection(connectionHops1[0], consensusStateManager);
-        dispatcherProxy.addNewConnection(connectionHops1[1], consensusStateManager);
+        dispatcherProxy.addNewConnection(connectionHops0[0], opLightClient);
+        dispatcherProxy.addNewConnection(connectionHops0[1], opLightClient);
+        dispatcherProxy.addNewConnection(connectionHops1[0], opLightClient);
+        dispatcherProxy.addNewConnection(connectionHops1[1], opLightClient);
         mars = new Mars(dispatcherProxy);
     }
 }

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -156,10 +156,10 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
         super.setUp();
         opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
-        dispatcherProxy.setNewConnection(connectionHops0[0], opLightClient);
-        dispatcherProxy.setNewConnection(connectionHops0[1], opLightClient);
-        dispatcherProxy.setNewConnection(connectionHops1[0], opLightClient);
-        dispatcherProxy.setNewConnection(connectionHops1[1], opLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops0[0], opLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops0[1], opLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops1[0], opLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops1[1], opLightClient);
         mars = new Mars(dispatcherProxy);
     }
 }

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -160,10 +160,10 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
         super.setUp();
         opLightClient = new OptimisticLightClient(1, opProofVerifier, l1BlockProvider);
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl("polyibc.eth1.");
-        dispatcherProxy.addNewConnection(connectionHops0[0], opLightClient);
-        dispatcherProxy.addNewConnection(connectionHops0[1], opLightClient);
-        dispatcherProxy.addNewConnection(connectionHops1[0], opLightClient);
-        dispatcherProxy.addNewConnection(connectionHops1[1], opLightClient);
+        dispatcherProxy.setNewConnection(connectionHops0[0], opLightClient);
+        dispatcherProxy.setNewConnection(connectionHops0[1], opLightClient);
+        dispatcherProxy.setNewConnection(connectionHops1[0], opLightClient);
+        dispatcherProxy.setNewConnection(connectionHops1[1], opLightClient);
         mars = new Mars(dispatcherProxy);
     }
 }

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -181,7 +181,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
 contract ChannelHandshakeTest is ChannelHandshakeTestSuite {
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
@@ -204,7 +204,7 @@ contract ChannelOpenTestBaseSetup is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
         ChannelHandshakeSetting memory setting =
             ChannelHandshakeSetting(ChannelOrder.ORDERED, feeEnabled, true, validProof);
 
@@ -521,9 +521,9 @@ contract DappRevertTests is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = TestUtilsTest.deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
-        dispatcherProxy.addNewConnection(connectionHops1[0], dummyLightClient);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops1[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
         revertingBytesMars = new RevertingBytesMars(dispatcherProxy);
         panickingMars = new PanickingMars(dispatcherProxy);
         revertingEmptyMars = new RevertingEmptyMars(dispatcherProxy);

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -181,7 +181,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
 contract ChannelHandshakeTest is ChannelHandshakeTestSuite {
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
@@ -204,7 +204,7 @@ contract ChannelOpenTestBaseSetup is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops[0], dummyLightClient);
         ChannelHandshakeSetting memory setting =
             ChannelHandshakeSetting(ChannelOrder.ORDERED, feeEnabled, true, validProof);
 
@@ -521,9 +521,9 @@ contract DappRevertTests is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = TestUtilsTest.deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection(connectionHops0[0], dummyLightClient);
-        dispatcherProxy.setNewConnection(connectionHops1[0], dummyLightClient);
-        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops1[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops[0], dummyLightClient);
         revertingBytesMars = new RevertingBytesMars(dispatcherProxy);
         panickingMars = new PanickingMars(dispatcherProxy);
         revertingEmptyMars = new RevertingEmptyMars(dispatcherProxy);

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -181,7 +181,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
 contract ChannelHandshakeTest is ChannelHandshakeTestSuite {
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
@@ -204,7 +204,7 @@ contract ChannelOpenTestBaseSetup is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
         ChannelHandshakeSetting memory setting =
             ChannelHandshakeSetting(ChannelOrder.ORDERED, feeEnabled, true, validProof);
 
@@ -521,9 +521,9 @@ contract DappRevertTests is Base {
 
     function setUp() public virtual override {
         (dispatcherProxy, dispatcherImplementation) = TestUtilsTest.deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops0[0], dummyConsStateManager);
-        dispatcherProxy.addNewConnection(connectionHops1[0], dummyConsStateManager);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops0[0], dummyLightClient);
+        dispatcherProxy.addNewConnection(connectionHops1[0], dummyLightClient);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
         revertingBytesMars = new RevertingBytesMars(dispatcherProxy);
         panickingMars = new PanickingMars(dispatcherProxy);
         revertingEmptyMars = new RevertingEmptyMars(dispatcherProxy);

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -180,7 +180,8 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
 
 contract ChannelHandshakeTest is ChannelHandshakeTestSuite {
     function setUp() public virtual override {
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
@@ -202,7 +203,8 @@ contract ChannelOpenTestBaseSetup is Base {
     RevertingBytesMars revertingBytesMars;
 
     function setUp() public virtual override {
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
         ChannelHandshakeSetting memory setting =
             ChannelHandshakeSetting(ChannelOrder.ORDERED, feeEnabled, true, validProof);
 
@@ -419,7 +421,8 @@ contract DispatcherAckPacketTestSuite is PacketSenderTestBase {
         IbcPacket memory packet = sentPacket;
         packet.src = invalidSrc;
 
-        vm.expectRevert(abi.encodeWithSelector(IBCErrors.packetCommitmentNotFound.selector));
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.channelIdNotFound.selector, packet.src.channelId));
+
         dispatcherProxy.acknowledgement(IbcReceiver(mars), packet, ackPacket, validProof);
     }
 }
@@ -487,7 +490,12 @@ contract DispatcherTimeoutPacketTestSuite is PacketSenderTestBase {
         IbcPacket memory packet = sentPacket;
         packet.src = invalidSrc;
 
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d310000000000000000000000000000000000000018); //
+        // Connection-1
+        _storeChannelidToConnectionMapping(packet.src.channelId, connectionStr);
+
         vm.expectRevert(abi.encodeWithSelector(IBCErrors.packetCommitmentNotFound.selector));
+        /* vm.expectRevert('Packet commitment not found'); */
         dispatcherProxy.timeout(IbcReceiver(mars), packet, validProof);
     }
 
@@ -512,8 +520,10 @@ contract DappRevertTests is Base {
         CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
 
     function setUp() public virtual override {
-        (dispatcherProxy, dispatcherImplementation) =
-            TestUtilsTest.deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
+        (dispatcherProxy, dispatcherImplementation) = TestUtilsTest.deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection(connectionHops0[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops1[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
         revertingBytesMars = new RevertingBytesMars(dispatcherProxy);
         panickingMars = new PanickingMars(dispatcherProxy);
         revertingEmptyMars = new RevertingEmptyMars(dispatcherProxy);
@@ -547,6 +557,10 @@ contract DappRevertTests is Base {
         packet.src.portId = ch0.portId;
         packet.src.channelId = ch0.channelId;
         packet.sequence = 1;
+
+        // Ack packet will check for an existing channel
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d300000000000000000000000000000000000000018); // Connection-0
+        _storeChannelidToConnectionMapping(ch1.channelId, connectionStr);
 
         // Test Revert Memory
         vm.expectEmit(true, true, true, true);
@@ -595,6 +609,9 @@ contract DappRevertTests is Base {
         bytes32 slot2 = keccak256(abi.encode(ch0.channelId, slot1));
         bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));
         vm.store(address(dispatcherProxy), slot3, bytes32(uint256(1)));
+
+        bytes32 connectionStr = bytes32(0x636f6e6e656374696f6e2d300000000000000000000000000000000000000018); // Connection-0
+        _storeChannelidToConnectionMapping(ch0.channelId, connectionStr);
 
         IbcPacket memory packet;
         packet.data = bytes("packet-1");

--- a/test/TestUtils.t.sol
+++ b/test/TestUtils.t.sol
@@ -2,10 +2,8 @@ import {IDispatcher} from "../contracts/interfaces/IDispatcher.sol";
 import {LightClient} from "../contracts/interfaces/LightClient.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
-// import {StdCheats} from "../forge-std/StdCheats.sol";
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
-// import {StdCheats} from "forge-std/StdCheats.sol";
 
 pragma solidity ^0.8.0;
 
@@ -14,7 +12,7 @@ abstract contract TestUtilsTest {
     bytes32 private constant _ROLLBACK_SLOT = 0x4910fdfa16fed3260ed0e7147f7cc6da11a60208b5b9406d12a635614ffd9143;
     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
-    function deployDispatcherProxyAndImpl(string memory initPortPrefix, LightClient lightClient)
+    function deployDispatcherProxyAndImpl(string memory initPortPrefix)
         public
         returns (IDispatcher proxy, Dispatcher dispatcherImplementation)
     {
@@ -23,7 +21,7 @@ abstract contract TestUtilsTest {
             address(
                 new ERC1967Proxy(
                     address(dispatcherImplementation),
-                    abi.encodeWithSelector(Dispatcher.initialize.selector, initPortPrefix, lightClient)
+                    abi.encodeWithSelector(Dispatcher.initialize.selector, initPortPrefix)
                 )
             )
         );

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -60,7 +60,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
     constructor(uint256 seed, string memory portPrefix) {
         _seed = seed;
 
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, new DummyLightClient());
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
         ucHandler = new UniversalChannelHandler(dispatcherProxy);
 
         mars = new Mars(dispatcherProxy);
@@ -73,6 +73,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
         connectionHops = new string[](2);
         connectionHops[0] = newConnectionId();
         connectionHops[1] = newConnectionId();
+        dispatcherProxy.addNewConnection(connectionHops[0], new DummyLightClient());
 
         mw1 = new GeneralMiddleware(1 << 1, address(ucHandler));
         mw2 = new GeneralMiddleware(1 << 2, address(ucHandler));

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -73,7 +73,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
         connectionHops = new string[](2);
         connectionHops[0] = newConnectionId();
         connectionHops[1] = newConnectionId();
-        dispatcherProxy.addNewConnection(connectionHops[0], new DummyLightClient());
+        dispatcherProxy.setNewConnection(connectionHops[0], new DummyLightClient());
 
         mw1 = new GeneralMiddleware(1 << 1, address(ucHandler));
         mw2 = new GeneralMiddleware(1 << 2, address(ucHandler));

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -73,7 +73,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
         connectionHops = new string[](2);
         connectionHops[0] = newConnectionId();
         connectionHops[1] = newConnectionId();
-        dispatcherProxy.setNewConnection(connectionHops[0], new DummyLightClient());
+        dispatcherProxy.setClientForConnection(connectionHops[0], new DummyLightClient());
 
         mw1 = new GeneralMiddleware(1 << 1, address(ucHandler));
         mw2 = new GeneralMiddleware(1 << 2, address(ucHandler));

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -112,7 +112,7 @@ contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
 contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils {
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -112,12 +112,11 @@ contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
 contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils {
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
 
-        LightClient newLightClient = opLightClient;
         // Add state to test if impacted by upgrade
         doChannelHandshake();
         sendPacket(_local.channelId);

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -23,13 +23,13 @@ import {DispatcherV2Initializable} from "./upgrades/DispatcherV2Initializable.so
 import {DispatcherV2} from "./upgrades/DispatcherV2.sol";
 
 abstract contract UpgradeTestUtils {
-    function upgradeDispatcher(LightClient consensusStateManager, string memory portPrefix, address dispatcherProxy)
+    function upgradeDispatcher(string memory portPrefix, address dispatcherProxy)
         public
         returns (DispatcherV2Initializable newDispatcherImplementation)
     {
         // Upgrade dispatcherProxy for tests
         newDispatcherImplementation = new DispatcherV2Initializable();
-        bytes memory initData = abi.encodeWithSignature("initialize(string,address)", portPrefix, consensusStateManager);
+        bytes memory initData = abi.encodeWithSignature("initialize(string)", portPrefix);
         UUPSUpgradeable(dispatcherProxy).upgradeToAndCall(address(newDispatcherImplementation), initData);
     }
 }
@@ -111,7 +111,8 @@ contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
 
 contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils {
     function setUp() public override {
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
@@ -122,7 +123,7 @@ contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils 
         sendPacket(_local.channelId);
 
         // Upgrade dispatcherProxy for tests
-        upgradeDispatcher(newLightClient, "adfsafsa", address(dispatcherProxy));
+        upgradeDispatcher("adfsafsa", address(dispatcherProxy));
     }
 
     function test_SentPacketState_Conserved() public {

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -112,7 +112,7 @@ contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
 contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils {
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
         mars = new Mars(dispatcherProxy);
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -21,31 +21,25 @@ contract DispatcherUUPSAccessControl is Base {
     DispatcherV2Initializable dispatcherImplementation3;
 
     function setUp() public override {
-        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
+        (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
         dispatcherImplementation2 = new DispatcherV2();
         dispatcherImplementation3 = new DispatcherV2Initializable();
     }
 
-    function test_Dispatcher_Allows_Upgrade() public {
+    function test_Dispatcher_Allows_Upgrade_123() public {
         assertEq(address(dispatcherImplementation), getProxyImplementation(address(dispatcherProxy), vm));
         UUPSUpgradeable(address(dispatcherProxy)).upgradeTo(address(dispatcherImplementation2));
         assertEq(address(dispatcherImplementation2), getProxyImplementation(address(dispatcherProxy), vm));
         assertEq(dispatcherProxy.portPrefix(), portPrefix);
-        assertEq(
-            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(110)))))),
-            address(dummyConsStateManager)
-        );
     }
 
     function test_Dispatcher_Allows_Upgrade_To_And_Call() public {
         assertEq(address(dispatcherImplementation), getProxyImplementation(address(dispatcherProxy), vm));
-        bytes memory initData = abi.encodeWithSignature("initialize(string,address)", portPrefix2, lightClient2);
+        bytes memory initData = abi.encodeWithSignature("initialize(string)", portPrefix2);
         UUPSUpgradeable(address(dispatcherProxy)).upgradeToAndCall(address(dispatcherImplementation3), initData);
         assertEq(address(dispatcherImplementation3), getProxyImplementation(address(dispatcherProxy), vm));
         assertEq(dispatcherProxy.portPrefix(), portPrefix2);
-        assertEq(
-            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(110)))))), address(lightClient2)
-        );
     }
 
     function test_Dispatcher_Prevents_Non_Owner_Updgrade() public {
@@ -61,6 +55,6 @@ contract DispatcherUUPSAccessControl is Base {
 
     function test_Dispatcher_Prevents_Reinit_Attacks() public {
         vm.expectRevert("Initializable: contract is already initialized");
-        dispatcherImplementation.initialize("IIpolyibc.eth.", dummyConsStateManager);
+        dispatcherImplementation.initialize("IIpolyibc.eth.");
     }
 }

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -22,7 +22,7 @@ contract DispatcherUUPSAccessControl is Base {
 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyConsStateManager);
+        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
         dispatcherImplementation2 = new DispatcherV2();
         dispatcherImplementation3 = new DispatcherV2Initializable();
     }

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -22,7 +22,7 @@ contract DispatcherUUPSAccessControl is Base {
 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.addNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
         dispatcherImplementation2 = new DispatcherV2();
         dispatcherImplementation3 = new DispatcherV2Initializable();
     }

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -22,7 +22,7 @@ contract DispatcherUUPSAccessControl is Base {
 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix);
-        dispatcherProxy.setNewConnection(connectionHops[0], dummyLightClient);
+        dispatcherProxy.setClientForConnection(connectionHops[0], dummyLightClient);
         dispatcherImplementation2 = new DispatcherV2();
         dispatcherImplementation3 = new DispatcherV2Initializable();
     }

--- a/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.9;
 
 import {DispatcherV2} from "./DispatcherV2.sol";
 import {LightClient} from "../../../contracts/interfaces/LightClient.sol";
+import {IBCErrors} from "../../../contracts/libs/Ibc.sol";
 /**
  * @title Dispatcher
  * @author Polymer Labs
@@ -13,10 +14,9 @@ import {LightClient} from "../../../contracts/interfaces/LightClient.sol";
  */
 
 contract DispatcherV2Initializable is DispatcherV2 {
-    function initialize(string memory initPortPrefix, LightClient _lightClient) public override reinitializer(2) {
+    function initialize(string memory initPortPrefix) public override reinitializer(2) {
         __Ownable_init();
         portPrefix = initPortPrefix;
         portPrefixLen = uint32(bytes(initPortPrefix).length);
-        lightClient = _lightClient;
     }
 }


### PR DESCRIPTION
PR to add multiclient support to our dispatcher contracts! Relatively simple, though I think most of the heavy lift should be on the web2 layer.  

We needed some way of adding the mapping what connections correspond to what clientIds. Right now, this is just done through a setter; as was the previously discussed solution. The setter is permissioned; only the owner can set which connections correspond to which clients.  The corollary to this is that, since connections depend on use of a light client, using connections is now permissioned as well (i.e. no one can use a connection that hasn't had a client set for it, and this client needs to be set by the owner). If someone tries to use a connection that doesn't have a client set for it or a channel that uses a connection that doesn't have a client set for it, the tx will revert.  I'm not sure if this is indeed what we want; we might want to make the connection to clientId setter permissionless so that anyone can add what client a connection maps to. 

Also, this connection to clientId mapping is immutable - once a connection's client is set, it can't be changed, even by the owner. In the case of an unpermissioned setter for connection to client mapping, this protects malicious actors from arbitrarily setting existing connections to malicious clients. 