### PR TITLE
add storage slots for future proxy upgrades

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -32,6 +32,8 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
  *     which can be relayed to a rollup module on the Polymerase chain
  */
 contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
+    uint256[49] private __gap;
+
     //
     // fields
     //
@@ -53,7 +55,12 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     // keep track of outbound ack packets to prevent replay attack
     mapping(address => mapping(bytes32 => mapping(uint64 => bool))) private _ackPacketCommitment;
 
-    LightClient _lightClient;
+    LightClient _lightClient; // Can't be set to immutable since it needs to be called in the initializer; not the
+
+    //////// NEW storage
+    mapping(bytes32 => string) private _channelIdToConnection;
+
+    // constructor
 
     //
     // methods
@@ -584,6 +591,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         _nextSequenceSend[address(portAddress)][local.channelId] = 1;
         _nextSequenceRecv[address(portAddress)][local.channelId] = 1;
         _nextSequenceAck[address(portAddress)][local.channelId] = 1;
+        _channelIdToConnection[local.channelId] = connectionHops[0]; // Set channel to connection mapping for finding
     }
 
     // Returns the result of the call if no revert, otherwise returns the error if thrown.

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -65,7 +65,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         // plant a fake packet commitment so the ack checks go through
         // Stdstore doesn't work for proxies so we have to use store
         // use "forge inspect --storage" to find the nested mapping slot
-        bytes32 slot1 = keccak256(abi.encode(address(mars), uint32(107))); // current nested mapping slot: 107
+        bytes32 slot1 = keccak256(abi.encode(address(mars), uint32(156))); // current nested mapping slot: 157
         bytes32 slot2 = keccak256(abi.encode(ch0.channelId, slot1));
         bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));
         vm.store(address(dispatcherProxy), slot3, bytes32(uint256(1)));

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -622,7 +622,7 @@ contract DappRevertTests is Base {
     function test_ack_packet_dapp_revert() public {
         // plant a fake packet commitment so the ack checks go through
         // use "forge inspect --storage" to find the slot
-        bytes32 slot1 = keccak256(abi.encode(address(revertingStringMars), uint32(107))); // current nested mapping
+        bytes32 slot1 = keccak256(abi.encode(address(revertingStringMars), uint32(156))); // current nested mapping
             // slot:
         bytes32 slot2 = keccak256(abi.encode(ch0.channelId, slot1));
         bytes32 slot3 = keccak256(abi.encode(uint256(1), slot2));

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -35,10 +35,10 @@ abstract contract UpgradeTestUtils {
 }
 
 contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
-    uint32 nextSequenceSendSlot = 104;
-    uint32 sendPacketCommitmentSlot = 107;
-    uint32 nextSequenceAckSlot = 106;
-    uint32 nextSequenceRecvSlot = 105;
+    uint32 nextSequenceSendSlot = 153;
+    uint32 sendPacketCommitmentSlot = 156;
+    uint32 nextSequenceAckSlot = 155;
+    uint32 nextSequenceRecvSlot = 154;
     IbcPacket[3] packets;
     string payload = "msgPayload";
     bytes packet = abi.encodePacked(payload);

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -32,7 +32,7 @@ contract DispatcherUUPSAccessControl is Base {
         assertEq(address(dispatcherImplementation2), getProxyImplementation(address(dispatcherProxy), vm));
         assertEq(dispatcherProxy.portPrefix(), portPrefix);
         assertEq(
-            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(110)))))),
+            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(159)))))),
             address(dummyConsStateManager)
         );
     }
@@ -44,7 +44,7 @@ contract DispatcherUUPSAccessControl is Base {
         assertEq(address(dispatcherImplementation3), getProxyImplementation(address(dispatcherProxy), vm));
         assertEq(dispatcherProxy.portPrefix(), portPrefix2);
         assertEq(
-            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(110)))))), address(lightClient2)
+            address(uint160(uint256(vm.load(address(dispatcherProxy), bytes32(uint256(159)))))), address(lightClient2)
         );
     }
 

--- a/test/upgradeableProxy/upgrades/DispatcherV2.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2.sol
@@ -31,6 +31,8 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
  *     which can be relayed to a rollup module on the Polymerase chain
  */
 contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
+    uint256[49] private __gap;
+
     //
     // fields
     //


### PR DESCRIPTION
This PR squashes these three commits from the `v2` branch.

```
* 9a551a2 (HEAD, tag: v2.0.0-catalyst) add setting channelIdToConnection RnkSngh <raunaksingh2.718@gmail.com>, 19 hours ago
* e4c11d8 (origin/raunak/storage-gap-uc) add minor comment RnkSngh <raunaksingh2.718@gmail.com>, 2 days ago
* 6c365d3 add storage gap for dispatcher proxy to allwo for upgrades RnkSngh <raunaksingh2.718@gmail.com>, 2 days ago
```

They have been tested with the e2e.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved storage optimization with the addition of new data structures in smart contracts.
	- Enhanced mapping of channel IDs to connections for better data handling.

- **Bug Fixes**
	- Adjusted nested mapping slot calculations for more accurate storage usage.
	- Updated values in contracts to ensure consistency and correct access control.

- **Refactor**
	- Modified initialization and settings in smart contracts for improved performance and reliability.
	- Updated upgrade utility and access control in dispatcher implementations for enhanced security and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->