### PR TITLE
Raunak/receiver fixes

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -13,7 +13,7 @@ import {LightClient} from "../interfaces/LightClient.sol";
 import {IDispatcher} from "../interfaces/IDispatcher.sol";
 import {
     Channel,
-    CounterParty,
+    ChannelEnd,
     ChannelOrder,
     IbcPacket,
     ChannelState,
@@ -131,11 +131,11 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenTry(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         if (bytes(counterparty.portId).length == 0) {
@@ -173,11 +173,11 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * The dApp should implement the onChannelConnect method to handle the third channel handshake method: ChanOpenAck
      */
     function channelOpenAck(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         _lightClient.verifyMembership(
@@ -206,11 +206,11 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * ChannelOpenConfirm
      */
     function channelOpenConfirm(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         _lightClient.verifyMembership(
@@ -541,11 +541,11 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
 
     function _connectChannel(
         IbcChannelReceiver portAddress,
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty
+        ChannelEnd calldata counterparty
     ) internal {
         // Register port and channel mapping
         // TODO: check duplicated channel registration?

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -103,7 +103,6 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenInit(
-        IbcChannelReceiver receiver,
         string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,
@@ -114,16 +113,15 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
             revert IBCErrors.invalidCounterPartyPortId();
         }
 
-        (bool success, bytes memory data) = _callIfContract(
-            address(receiver), abi.encodeWithSelector(IbcChannelReceiver.onChanOpenInit.selector, version)
-        );
+        (bool success, bytes memory data) =
+            _callIfContract(msg.sender, abi.encodeWithSelector(IbcChannelReceiver.onChanOpenInit.selector, version));
 
         if (success) {
             emit ChannelOpenInit(
-                address(receiver), abi.decode(data, (string)), ordering, feeEnabled, connectionHops, counterpartyPortId
+                msg.sender, abi.decode(data, (string)), ordering, feeEnabled, connectionHops, counterpartyPortId
             );
         } else {
-            emit ChannelOpenInitError(address(receiver), data);
+            emit ChannelOpenInitError(msg.sender, data);
         }
     }
 

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -528,10 +528,6 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     //     isMatch = Ibc._hexStrToAddress(portSuffix) == addr;
     // }
 
-    function _getAddressFromPort(string calldata port) internal view returns (address) {
-        return Ibc._hexStrToAddress(port[portPrefixLen:]);
-    }
-
     // Prerequisite: must verify sender is authorized to send packet on the channel
     function _sendPacket(address sender, bytes32 channelId, bytes memory packet, uint64 timeoutTimestamp) internal {
         // current packet sequence
@@ -600,5 +596,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
             // TODO: check timeoutHeight.revision_number?
             || (packet.timeoutHeight.revision_height != 0 && block.number >= packet.timeoutHeight.revision_height)
         );
+    }
+
+    function _getAddressFromPort(string calldata port) internal view returns (address addr) {
+        addr = Ibc._hexStrToAddress(port[portPrefixLen:]);
     }
 }

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -475,12 +475,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * Generate a timeout packet for the given packet
      */
     function writeTimeoutPacket(IbcPacket calldata packet) external {
-        // verify `receiver` is the original packet sender
-        // if (!portIdAddressMatch(receiver, packet.src.portId)) {
-        //     revert IBCErrors.receiverNotIntendedPacketDestination();
-        // }
-
-        address receiver = _getAddressFromPort(packet.dest.portId);
+        address receiver = _getAddressFromPort(packet.src.portId);
         // verify packet does not have a receipt
         bool hasReceipt = _recvPacketReceipt[receiver][packet.dest.channelId][packet.sequence];
         if (hasReceipt) {

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -12,7 +12,7 @@ import {
     IbcMwEventsEmitter
 } from "../interfaces/IbcMiddleware.sol";
 import {IbcReceiver, IbcReceiverBase} from "../interfaces/IbcReceiver.sol";
-import {ChannelOrder, CounterParty, IbcPacket, AckPacket, UniversalPacket, IbcUtils} from "../libs/Ibc.sol";
+import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket, UniversalPacket, IbcUtils} from "../libs/Ibc.sol";
 
 contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
     bytes32[] public connectedChannels;

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -48,6 +48,16 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
         if (!channelFound) revert ChannelNotFound();
     }
 
+    function openChannel(
+        string calldata version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        string calldata counterpartyPortId
+    ) external onlyOwner {
+        dispatcher.channelOpenInit(version, ordering, feeEnabled, connectionHops, counterpartyPortId);
+    }
+
     function sendUniversalPacket(
         bytes32 channelId,
         bytes32 destPortAddr,

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.9;
 import {IBCErrors, AckPacket, ChannelOrder, CounterParty} from "../libs/Ibc.sol";
 import {IbcReceiverBase, IbcReceiver, IbcPacket} from "../interfaces/IbcReceiver.sol";
 import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
+import {console2} from "forge-std/Console2.sol";
 
 contract Mars is IbcReceiverBase, IbcReceiver {
     // received packet as chain B
@@ -71,6 +72,7 @@ contract Mars is IbcReceiverBase, IbcReceiver {
     }
 
     function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external virtual onlyIbcDispatcher {
+        console2.log("dispatcher", address(dispatcher));
         _connectChannel(channelId, counterpartyVersion);
     }
 

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -20,12 +20,13 @@ contract Mars is IbcReceiverBase, IbcReceiver {
     constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}
 
     function triggerChannelInit(
+        string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
         string calldata counterpartyPortId
     ) external onlyOwner {
-        dispatcher.channelOpenInit(supportedVersions[0], ordering, feeEnabled, connectionHops, counterpartyPortId);
+        dispatcher.channelOpenInit(version, ordering, feeEnabled, connectionHops, counterpartyPortId);
     }
 
     function onRecvPacket(IbcPacket memory packet)

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.9;
 import {IBCErrors, AckPacket, ChannelOrder, CounterParty} from "../libs/Ibc.sol";
 import {IbcReceiverBase, IbcReceiver, IbcPacket} from "../interfaces/IbcReceiver.sol";
 import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
-import {console2} from "forge-std/Console2.sol";
 
 contract Mars is IbcReceiverBase, IbcReceiver {
     // received packet as chain B
@@ -19,6 +18,15 @@ contract Mars is IbcReceiverBase, IbcReceiver {
     string[] public supportedVersions = ["1.0", "2.0"];
 
     constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}
+
+    function triggerChannelInit(
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        string calldata counterpartyPortId
+    ) external onlyOwner {
+        dispatcher.channelOpenInit(supportedVersions[0], ordering, feeEnabled, connectionHops, counterpartyPortId);
+    }
 
     function onRecvPacket(IbcPacket memory packet)
         external
@@ -72,7 +80,6 @@ contract Mars is IbcReceiverBase, IbcReceiver {
     }
 
     function onChanOpenAck(bytes32 channelId, string calldata counterpartyVersion) external virtual onlyIbcDispatcher {
-        console2.log("dispatcher", address(dispatcher));
         _connectChannel(channelId, counterpartyVersion);
     }
 

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import {IBCErrors, AckPacket, ChannelOrder, CounterParty} from "../libs/Ibc.sol";
+import {IBCErrors, AckPacket, ChannelOrder, ChannelEnd} from "../libs/Ibc.sol";
 import {IbcReceiverBase, IbcReceiver, IbcPacket} from "../interfaces/IbcReceiver.sol";
 import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
 

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -7,7 +7,7 @@ import {L1Header, OpL2StateProof, Ics23Proof} from "./ProofVerifier.sol";
 import {IbcChannelReceiver, IbcPacketReceiver} from "./IbcReceiver.sol";
 import {
     Channel,
-    CounterParty,
+    ChannelEnd,
     ChannelOrder,
     IbcPacket,
     ChannelState,
@@ -46,11 +46,11 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenTry(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external;
 
@@ -59,11 +59,11 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * The dApp should implement the onChannelConnect method to handle the third channel handshake method: ChanOpenAck
      */
     function channelOpenAck(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external;
 
@@ -73,11 +73,11 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * ChannelOpenConfirm
      */
     function channelOpenConfirm(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external;
 

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -47,7 +47,6 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenTry(
-        IbcChannelReceiver portAddress,
         CounterParty calldata local,
         ChannelOrder ordering,
         bool feeEnabled,
@@ -61,7 +60,6 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * The dApp should implement the onChannelConnect method to handle the third channel handshake method: ChanOpenAck
      */
     function channelOpenAck(
-        IbcChannelReceiver portAddress,
         CounterParty calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
@@ -76,7 +74,6 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * ChannelOpenConfirm
      */
     function channelOpenConfirm(
-        IbcChannelReceiver portAddress,
         CounterParty calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
@@ -89,23 +86,16 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
 
     function sendPacket(bytes32 channelId, bytes calldata packet, uint64 timeoutTimestamp) external;
 
-    function acknowledgement(
-        IbcPacketReceiver receiver,
-        IbcPacket calldata packet,
-        bytes calldata ack,
-        Ics23Proof calldata proof
-    ) external;
+    function acknowledgement(IbcPacket calldata packet, bytes calldata ack, Ics23Proof calldata proof) external;
 
-    function timeout(IbcPacketReceiver receiver, IbcPacket calldata packet, Ics23Proof calldata proof) external;
+    function timeout(IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
-    function recvPacket(IbcPacketReceiver receiver, IbcPacket calldata packet, Ics23Proof calldata proof) external;
+    function recvPacket(IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
     function getOptimisticConsensusState(uint256 height)
         external
         view
         returns (uint256 appHash, uint256 fraudProofEndTime, bool ended);
-
-    function portIdAddressMatch(address addr, string calldata portId) external view returns (bool isMatch);
 
     function getChannel(address portAddress, bytes32 channelId) external view returns (Channel memory channel);
 }

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -33,7 +33,6 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenInit(
-        IbcChannelReceiver portAddress,
         string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.9;
 
-import {Height, CounterParty, ChannelOrder, AckPacket} from "../libs/Ibc.sol";
+import {Height, ChannelEnd, ChannelOrder, AckPacket} from "../libs/Ibc.sol";
 import {IbcChannelReceiver} from "./IbcReceiver.sol";
 import {Ics23Proof} from "./ProofVerifier.sol";
 

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -24,7 +24,6 @@ interface IbcPacketSender {
  */
 interface IbcDispatcher is IbcPacketSender {
     function channelOpenInit(
-        IbcChannelReceiver receiver,
         string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IbcDispatcher} from "./IbcDispatcher.sol";
-import {ChannelOrder, CounterParty, IbcPacket, AckPacket} from "../libs/Ibc.sol";
+import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket} from "../libs/Ibc.sol";
 
 /**
  * @title IbcChannelReceiver

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.9;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ProtoChannel, ProtoCounterparty} from "proto/channel.sol";
 import {Base64} from "base64/base64.sol";
-import {console2} from "forge-std/console2.sol";
 
 /**
  * Ibc.sol
@@ -286,7 +285,6 @@ library Ibc {
      * hexStr is case-insensitive.
      */
     function _hexStrToAddress(string memory hexStr) external pure returns (address addr) {
-        console2.log("length", bytes(hexStr).length);
         if (bytes(hexStr).length != 40) {
             revert IBCErrors.invalidHexStringLength();
         }

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.9;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ProtoChannel, ProtoCounterparty} from "proto/channel.sol";
 import {Base64} from "base64/base64.sol";
+import {console2} from "forge-std/console2.sol";
 
 /**
  * Ibc.sol
@@ -285,6 +286,7 @@ library Ibc {
      * hexStr is case-insensitive.
      */
     function _hexStrToAddress(string memory hexStr) external pure returns (address addr) {
+        console2.log("length", bytes(hexStr).length);
         if (bytes(hexStr).length != 40) {
             revert IBCErrors.invalidHexStringLength();
         }

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -114,7 +114,7 @@ struct Channel {
     bytes32 counterpartyChannelId;
 }
 
-struct CounterParty {
+struct ChannelEnd {
     string portId;
     bytes32 channelId;
     string version;
@@ -227,7 +227,7 @@ library IbcUtils {
 
     // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
     // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
-    function isChannelOpenTry(CounterParty calldata counterparty) public pure returns (bool open) {
+    function isChannelOpenTry(ChannelEnd calldata counterparty) public pure returns (bool open) {
         if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
             return false;
             // ChanOpenInit with unknow conterparty
@@ -313,7 +313,7 @@ library Ibc {
 
     // For XXXX => vIBC direction, SC needs to verify the proof of membership of TRY_PENDING
     // For vIBC initiated channel, SC doesn't need to verify any proof, and these should be all empty
-    function _isChannelOpenTry(CounterParty calldata counterparty) external pure returns (bool open) {
+    function _isChannelOpenTry(ChannelEnd calldata counterparty) external pure returns (bool open) {
         if (counterparty.channelId == bytes32(0) && bytes(counterparty.version).length == 0) {
             open = false;
             // ChanOpenInit with unknow conterparty
@@ -374,7 +374,7 @@ library Ibc {
         ChannelOrder ordering,
         string calldata version,
         string[] calldata connectionHops,
-        CounterParty calldata counterparty
+        ChannelEnd calldata counterparty
     ) public pure returns (bytes memory proofValue) {
         proofValue = ProtoChannel.encode(
             ProtoChannel.Data(

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,16 +6,10 @@ libs = ['lib']
 test = 'test'
 cache_path  = 'forge-cache'
 gas_reports = ['*']
-fs_permissions = [{ access = 'read', path = './test/payload'}]
+fs_permissions = [{ access = 'read', path = './test/payload'}, { access = 'read', path = './out'}]
 [fmt]
 wrap_comments = true
 number_underscore = "thousands"
 ignore = ["lib/*"]
-
-[rpc_endpoints]
-sepolia = "${SEPOLIA_RPC_URL}"
-
-[etherscan]
-sepolia = { key = "${ETHERSCAN_API_KEY}" }
 
 # See more config options https://book.getfoundry.sh/reference/config.html

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 import "../contracts/utils/DummyProofVerifier.sol";
 import "../contracts/utils/DummyLightClient.sol";
 import "../contracts/core/Dispatcher.sol";
-import "../contracts/examples/Mars.sol";
+import {Mars} from "../contracts/examples/Mars.sol";
 import {IDispatcher} from "../contracts/core/Dispatcher.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "../contracts/core/OpProofVerifier.sol";

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -73,7 +73,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function channelOpenInit(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
+    function channelOpenInit(LocalEnd memory le, ChannelEnd memory re, ChannelHandshakeSetting memory s, bool expPass)
         public
     {
         vm.startPrank(address(le.receiver));
@@ -95,7 +95,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function channelOpenTry(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
+    function channelOpenTry(LocalEnd memory le, ChannelEnd memory re, ChannelHandshakeSetting memory s, bool expPass)
         public
     {
         if (expPass) {
@@ -110,9 +110,9 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
                 re.channelId
             );
         }
-        CounterParty memory cp = CounterParty(re.portId, re.channelId, re.version);
+        ChannelEnd memory cp = ChannelEnd(re.portId, re.channelId, re.version);
         dispatcherProxy.channelOpenTry(
-            CounterParty(le.portId, le.channelId, le.versionCall),
+            ChannelEnd(le.portId, le.channelId, le.versionCall),
             s.ordering,
             s.feeEnabled,
             le.connectionHops,
@@ -129,7 +129,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
      * @param expPass Expected pass status of the operation.
      * If expPass is false, `vm.expectRevert` should be called before this function.
      */
-    function channelOpenAck(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
+    function channelOpenAck(LocalEnd memory le, ChannelEnd memory re, ChannelHandshakeSetting memory s, bool expPass)
         public
     {
         if (expPass) {
@@ -137,7 +137,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             emit ChannelOpenAck(address(le.receiver), le.channelId);
         }
         dispatcherProxy.channelOpenAck(
-            CounterParty(le.portId, le.channelId, le.versionCall),
+            ChannelEnd(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,
             s.feeEnabled,
@@ -156,7 +156,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
      */
     function channelOpenConfirm(
         LocalEnd memory le,
-        CounterParty memory re,
+        ChannelEnd memory re,
         ChannelHandshakeSetting memory s,
         bool expPass
     ) public {
@@ -165,7 +165,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             emit ChannelOpenConfirm(address(le.receiver), le.channelId);
         }
         dispatcherProxy.channelOpenConfirm(
-            CounterParty(le.portId, le.channelId, le.versionCall),
+            ChannelEnd(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,
             s.feeEnabled,

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -8,7 +8,6 @@ import {Dispatcher} from "../contracts/core/Dispatcher.sol";
 import {IDispatcher} from "../contracts/interfaces/IDispatcher.sol";
 import {IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
 import {IbcChannelReceiver} from "../contracts/interfaces/IbcReceiver.sol";
-import "../contracts/examples/Mars.sol";
 import "../contracts/core/OpLightClient.sol";
 import "../contracts/utils/DummyLightClient.sol";
 import "../contracts/core/OpProofVerifier.sol";
@@ -83,9 +82,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
                 address(le.receiver), le.versionExpected, s.ordering, s.feeEnabled, le.connectionHops, re.portId
             );
         }
-        dispatcherProxy.channelOpenInit(
-            le.receiver, le.versionCall, s.ordering, s.feeEnabled, le.connectionHops, re.portId
-        );
+        dispatcherProxy.channelOpenInit(le.versionCall, s.ordering, s.feeEnabled, le.connectionHops, re.portId);
     }
 
     /**

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -113,7 +113,6 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
         }
         CounterParty memory cp = CounterParty(re.portId, re.channelId, re.version);
         dispatcherProxy.channelOpenTry(
-            le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             s.ordering,
             s.feeEnabled,
@@ -139,7 +138,6 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             emit ChannelOpenAck(address(le.receiver), le.channelId);
         }
         dispatcherProxy.channelOpenAck(
-            le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,
@@ -168,7 +166,6 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             emit ChannelOpenConfirm(address(le.receiver), le.channelId);
         }
         dispatcherProxy.channelOpenConfirm(
-            le.receiver,
             CounterParty(le.portId, le.channelId, le.versionCall),
             le.connectionHops,
             s.ordering,

--- a/test/Dispatcher.base.t.sol
+++ b/test/Dispatcher.base.t.sol
@@ -76,6 +76,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     function channelOpenInit(LocalEnd memory le, CounterParty memory re, ChannelHandshakeSetting memory s, bool expPass)
         public
     {
+        vm.startPrank(address(le.receiver));
         if (expPass) {
             vm.expectEmit(true, true, true, true);
             emit ChannelOpenInit(
@@ -83,6 +84,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
             );
         }
         dispatcherProxy.channelOpenInit(le.versionCall, s.ordering, s.feeEnabled, le.connectionHops, re.portId);
+        vm.stopPrank();
     }
 
     /**

--- a/test/Dispatcher.client.t.sol
+++ b/test/Dispatcher.client.t.sol
@@ -7,7 +7,6 @@ import {IDispatcher} from "../contracts/interfaces/IDispatcher.sol";
 import {IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
 import {IbcReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import "../contracts/examples/Mars.sol";
 import "../contracts/core/OpLightClient.sol";
 import "./Dispatcher.base.t.sol";
 

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -38,7 +38,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         vm.expectEmit(true, true, true, true);
         emit ChannelOpenTry(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch0.portId, ch0.channelId);
 
-        dispatcherProxy.channelOpenTry(mars, ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
+        dispatcherProxy.channelOpenTry(ch1, ChannelOrder.NONE, false, connectionHops1, ch0, proof);
     }
 
     function test_ibc_channel_ack() public {
@@ -47,7 +47,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         vm.expectEmit(true, true, true, true);
         emit ChannelOpenAck(address(mars), ch0.channelId);
 
-        dispatcherProxy.channelOpenAck(mars, ch0, connectionHops0, ChannelOrder.NONE, false, ch1, proof);
+        dispatcherProxy.channelOpenAck(ch0, connectionHops0, ChannelOrder.NONE, false, ch1, proof);
     }
 
     function test_ibc_channel_confirm() public {
@@ -56,7 +56,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         vm.expectEmit(true, true, true, true);
         emit ChannelOpenConfirm(address(mars), ch1.channelId);
 
-        dispatcherProxy.channelOpenConfirm(mars, ch1, connectionHops1, ChannelOrder.NONE, false, ch0, proof);
+        dispatcherProxy.channelOpenConfirm(ch1, connectionHops1, ChannelOrder.NONE, false, ch0, proof);
     }
 
     function test_ack_packet() public {
@@ -86,7 +86,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         vm.expectEmit(true, true, true, true);
         emit Acknowledgement(address(mars), packet.src.channelId, packet.sequence);
 
-        dispatcherProxy.acknowledgement(mars, packet, ack, proof);
+        dispatcherProxy.acknowledgement(packet, ack, proof);
     }
 
     function test_recv_packet() public {
@@ -109,7 +109,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
             packet.sequence,
             AckPacket(true, abi.encodePacked('{ "account": "account", "reply": "got the message" }'))
         );
-        dispatcherProxy.recvPacket(mars, packet, proof);
+        dispatcherProxy.recvPacket(packet, proof);
     }
 
     function test_timeout_packet() public {

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -32,6 +32,7 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
         emit ChannelOpenInit(address(mars), "1.0", ChannelOrder.NONE, false, connectionHops1, ch1.portId);
 
         // since this is open chann init, the proof is not used. so use an invalid one
+        vm.prank(address(mars));
         dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch1.portId);
     }
 
@@ -144,34 +145,11 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix1, consensusStateManager);
 
         address targetMarsAddress = 0x71C95911E9a5D330f4D621842EC243EE1343292e;
-        Mars marsTemplate = new Mars(dispatcherProxy);
         deployCodeTo("Mars.sol", abi.encode(address(dispatcherProxy)), targetMarsAddress);
-        // vm.etch(targetMarsAddress, address(marsTemplate).code);
-        // vm.store(targetMarsAddress, bytes32(uint256(1)), bytes32(uint256(uint160(address(dispatcherProxy)))));
-        // vm.store(targetMarsAddress, bytes32(uint256(0)), bytes32(uint256(uint160(address(dispatcherProxy)))));
+        mars = Mars(payable(targetMarsAddress));
 
-        Mars mars = Mars(payable(targetMarsAddress));
-        // mars = new Mars(dispatcherProxy);
-        // mars = Mars()
-
-        // CounterParty ch0 = CounterParty(
-        //     "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0"
-        // );
-        // CounterParty ch1 = CounterParty(
-        //     "polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0"
-        // );
-
-        // portId1 = IbcUtils.addressToPortId(portPrefix1, address(mars));
-        // portId2 = IbcUtils.addressToPortId(portPrefix2, address(mars));
         portId1 = "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e";
         portId2 = "polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e";
-        console2.log("portId1 ", portId1);
-        console2.log("portId2 ", portId2);
-        console2.log("owner", address(mars.dispatcher()), "dispatcher", address(dispatcherProxy));
-        console2.logBytes32(vm.load(address(mars), bytes32(uint256(0))));
-        console2.logBytes32(vm.load(address(marsTemplate), bytes32(uint256(0))));
-        console2.logBytes32(vm.load(address(mars), bytes32(uint256(1))));
-        console2.logBytes32(vm.load(address(marsTemplate), bytes32(uint256(1))));
         ch0 = CounterParty(portId1, IbcUtils.toBytes32("channel-0"), "1.0");
         ch1 = CounterParty(portId2, IbcUtils.toBytes32("channel-1"), "1.0");
     }

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -22,8 +22,8 @@ abstract contract DispatcherIbcWithRealProofsSuite is IbcEventsEmitter, Base {
     Mars mars;
     OptimisticLightClient consensusStateManager;
 
-    CounterParty ch0;
-    CounterParty ch1;
+    ChannelEnd ch0;
+    ChannelEnd ch1;
     string[] connectionHops0 = ["connection-0", "connection-3"];
     string[] connectionHops1 = ["connection-2", "connection-1"];
 
@@ -150,7 +150,7 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
 
         portId1 = "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e";
         portId2 = "polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e";
-        ch0 = CounterParty(portId1, IbcUtils.toBytes32("channel-0"), "1.0");
-        ch1 = CounterParty(portId2, IbcUtils.toBytes32("channel-1"), "1.0");
+        ch0 = ChannelEnd(portId1, IbcUtils.toBytes32("channel-0"), "1.0");
+        ch1 = ChannelEnd(portId2, IbcUtils.toBytes32("channel-1"), "1.0");
     }
 }

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -21,7 +21,7 @@ abstract contract ChannelHandshakeUtils is Base {
     string portId;
     LocalEnd _local;
     Mars mars;
-    CounterParty _remote;
+    ChannelEnd _remote;
 
     function createSettings(bool localInitiate, bool isProofValid)
         internal
@@ -59,7 +59,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 // remoteEnd has no channelId or version if localEnd is the initiator
@@ -74,7 +74,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 re.version = versions[j];
                 // explicit version
                 le.versionCall = versions[j];
@@ -96,7 +96,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 re.version = versions[j];
@@ -114,7 +114,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 vm.expectEmit(true, true, true, true);
@@ -133,7 +133,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 vm.expectRevert(DummyLightClient.InvalidDummyMembershipProof.selector);
@@ -149,7 +149,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 // no remote version applied in openChannel
                 channelOpenInit(le, re, settings[i], true);
                 channelOpenTry(le, re, settings[i], true);
@@ -171,7 +171,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 // no remote version applied in openChannel
                 channelOpenInit(le, re, settings[i], true);
                 channelOpenTry(le, re, settings[i], true);
@@ -190,7 +190,7 @@ contract ChannelHandshakeTest is ChannelHandshakeTestSuite {
         mars = new Mars(dispatcherProxy);
         portId = IbcUtils.addressToPortId(portPrefix, address(mars));
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
-        _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
+        _remote = ChannelEnd("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
     }
 }
 
@@ -205,7 +205,7 @@ contract ChannelOpenTestBaseSetup is Base {
 
     LocalEnd _local;
     LocalEnd _localRevertingMars;
-    CounterParty _remote;
+    ChannelEnd _remote;
     Mars mars;
     RevertingBytesMars revertingBytesMars;
 
@@ -225,7 +225,7 @@ contract ChannelOpenTestBaseSetup is Base {
         _local = LocalEnd(mars, portId, channelId, connectionHops, "1.0", "1.0");
         _localRevertingMars =
             LocalEnd(revertingBytesMars, revertingBytesMarsPortId, channelId, connectionHops, "1.0", "1.0");
-        _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
+        _remote = ChannelEnd("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
 
         vm.stopPrank();
         channelOpenInit(_local, _remote, setting, true);
@@ -561,10 +561,10 @@ contract DappRevertTests is Base {
     RevertingStringMars revertingStringMars;
     string[] connectionHops0 = ["connection-0", "connection-3"];
     string[] connectionHops1 = ["connection-2", "connection-1"];
-    CounterParty ch0 =
-        CounterParty("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
-    CounterParty ch1 =
-        CounterParty("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
+    ChannelEnd ch0 =
+        ChannelEnd("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
+    ChannelEnd ch1 =
+        ChannelEnd("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) =

--- a/test/Dispatcher.t.sol
+++ b/test/Dispatcher.t.sol
@@ -4,9 +4,15 @@ pragma solidity ^0.8.13;
 import "../contracts/libs/Ibc.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
 import {IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
-import {IbcReceiver} from "../contracts/interfaces/IbcReceiver.sol";
+import {IbcReceiver, IbcReceiverBase} from "../contracts/interfaces/IbcReceiver.sol";
 import {DummyLightClient} from "../contracts/utils/DummyLightClient.sol";
-import "../contracts/examples/Mars.sol";
+import {
+    Mars,
+    RevertingBytesMars,
+    PanickingMars,
+    RevertingEmptyMars,
+    RevertingStringMars
+} from "../contracts/examples/Mars.sol";
 import "../contracts/core/OpLightClient.sol";
 import "./Dispatcher.base.t.sol";
 import {Earth} from "../contracts/examples/Earth.sol";
@@ -535,9 +541,9 @@ contract DappRevertTests is Base {
     string[] connectionHops0 = ["connection-0", "connection-3"];
     string[] connectionHops1 = ["connection-2", "connection-1"];
     CounterParty ch0 =
-        CounterParty("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
+        CounterParty("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
     CounterParty ch1 =
-        CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
+        CounterParty("polyibc.eth.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "1.0");
 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) =
@@ -552,17 +558,13 @@ contract DappRevertTests is Base {
         address nonDappAddr = vm.addr(1);
 
         emit ChannelOpenInitError(nonDappAddr, bytes("call to non-contract"));
-        dispatcherProxy.channelOpenInit(
-            IbcChannelReceiver(nonDappAddr), ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
-        );
+        dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
 
     function test_ibc_channel_open_dapp_without_handler() public {
         Earth earth = new Earth(vm.addr(1));
         emit ChannelOpenInitError(address(earth), "");
-        dispatcherProxy.channelOpenInit(
-            IbcChannelReceiver(address(earth)), ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
-        );
+        dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
 
     function test_recv_packet_callback_revert_and_panic() public {
@@ -650,9 +652,7 @@ contract DappRevertTests is Base {
         emit ChannelOpenInitError(
             address(revertingStringMars), abi.encodeWithSignature("Error(string)", "open ibc channel is reverting")
         );
-        dispatcherProxy.channelOpenInit(
-            revertingStringMars, ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId
-        );
+        dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
 
     function test_ibc_channel_ack_dapp_revert() public {

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -82,9 +82,8 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         connectionHops[0] = "connection-2";
         connectionHops[1] = "connection-1";
 
-        CounterParty memory counterparty = CounterParty(
-            "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0"
-        );
+        ChannelEnd memory counterparty =
+            ChannelEnd("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
         this.run_packet_proof_verification(
             input,
             Ibc.channelProofKey(
@@ -103,8 +102,8 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         connectionHops[0] = "connection-0";
         connectionHops[1] = "connection-3";
 
-        CounterParty memory counterparty =
-            CounterParty("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "");
+        ChannelEnd memory counterparty =
+            ChannelEnd("polyibc.eth2.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-1"), "");
         this.run_packet_proof_verification(
             input,
             Ibc.channelProofKey(
@@ -123,9 +122,8 @@ contract OpProofVerifierMembershipVerificationTest is ProofBase {
         connectionHops[0] = "connection-2";
         connectionHops[1] = "connection-1";
 
-        CounterParty memory counterparty = CounterParty(
-            "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0"
-        );
+        ChannelEnd memory counterparty =
+            ChannelEnd("polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e", IbcUtils.toBytes32("channel-0"), "1.0");
         this.run_packet_proof_verification(
             input,
             Ibc.channelProofKey(

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -200,7 +200,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             );
         }
         dispatcherProxy.channelOpenTry(
-            CounterParty(
+            ChannelEnd(
                 IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)),
                 setting.channelId,
                 setting.version
@@ -208,7 +208,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             setting.ordering,
             setting.feeEnabled,
             connectionHops,
-            CounterParty(cpPortId, cpChanId, setting.version),
+            ChannelEnd(cpPortId, cpChanId, setting.version),
             setting.proof
         );
     }
@@ -238,13 +238,13 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenAck(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenAck(
-            CounterParty(
+            ChannelEnd(
                 IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)), chanId, setting.version
             ),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,
-            CounterParty(cpPortId, cpChanId, setting.version),
+            ChannelEnd(cpPortId, cpChanId, setting.version),
             setting.proof
         );
     }
@@ -274,20 +274,20 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenConfirm(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenConfirm(
-            CounterParty(
+            ChannelEnd(
                 IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)), chanId, setting.version
             ),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,
-            CounterParty(cpPortId, cpChanId, setting.version),
+            ChannelEnd(cpPortId, cpChanId, setting.version),
             setting.proof
         );
     }
 
     // Converts a local dApp address on this virtual chain to a Counterparty struct for a remote chain
-    function localEndToCounterparty(address localEnd) external view returns (CounterParty memory) {
-        return CounterParty(portIds[localEnd], channelIds[localEnd][address(this)], "");
+    function localEndToCounterparty(address localEnd) external view returns (ChannelEnd memory) {
+        return ChannelEnd(portIds[localEnd], channelIds[localEnd][address(this)], "");
     }
 
     function setChannelId(IbcChannelReceiver localEnd, IbcChannelReceiver remoteEnd, bytes32 channelId) external {

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -201,7 +201,6 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             );
         }
         dispatcherProxy.channelOpenTry(
-            localEnd,
             CounterParty(setting.portId, setting.channelId, setting.version),
             setting.ordering,
             setting.feeEnabled,
@@ -236,7 +235,6 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenAck(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenAck(
-            localEnd,
             CounterParty(setting.portId, chanId, setting.version),
             connectionHops,
             setting.ordering,
@@ -271,7 +269,6 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenConfirm(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenConfirm(
-            localEnd,
             CounterParty(setting.portId, chanId, setting.version),
             connectionHops,
             setting.ordering,

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -167,9 +167,8 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
                 remoteChain.portIds(address(remoteEnd))
             );
         }
-        dispatcherProxy.channelOpenInit(
-            setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId
-        );
+        vm.prank(address(ucHandler));
+        dispatcherProxy.channelOpenInit(setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId);
     }
 
     function channelOpenTry(
@@ -201,7 +200,11 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             );
         }
         dispatcherProxy.channelOpenTry(
-            CounterParty(setting.portId, setting.channelId, setting.version),
+            CounterParty(
+                IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)),
+                setting.channelId,
+                setting.version
+            ),
             setting.ordering,
             setting.feeEnabled,
             connectionHops,
@@ -235,7 +238,9 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenAck(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenAck(
-            CounterParty(setting.portId, chanId, setting.version),
+            CounterParty(
+                IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)), chanId, setting.version
+            ),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,
@@ -269,7 +274,9 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             emit ChannelOpenConfirm(address(localEnd), chanId);
         }
         dispatcherProxy.channelOpenConfirm(
-            CounterParty(setting.portId, chanId, setting.version),
+            CounterParty(
+                IbcUtils.addressToPortId(dispatcherProxy.portPrefix(), address(localEnd)), chanId, setting.version
+            ),
             connectionHops,
             setting.ordering,
             setting.feeEnabled,

--- a/test/VirtualChain.sol
+++ b/test/VirtualChain.sol
@@ -168,7 +168,7 @@ contract VirtualChain is Test, IbcEventsEmitter, TestUtilsTest {
             );
         }
         dispatcherProxy.channelOpenInit(
-            localEnd, setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId
+            setting.version, setting.ordering, setting.feeEnabled, connectionHops, cpPortId
         );
     }
 

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -302,7 +302,7 @@ contract UniversalChannelPacketTest is Base, IbcMwEventsEmitter {
             vm.expectEmit(true, true, true, true);
             emit Timeout(address(v1.ucHandler), channelId1, packetSeq);
             // receive ack on chain A, triggering expected events
-            v1.dispatcherProxy.timeout(v1.ucHandler, recvPacket, validProof);
+            v1.dispatcherProxy.timeout(recvPacket, validProof);
 
             // verify timeout packet received by Earth on chain A
             (gotChannelId, gotUcPacket) = v1.earth.timeoutPackets(packetSeq - 1);
@@ -388,7 +388,7 @@ contract UniversalChannelPacketTest is Base, IbcMwEventsEmitter {
             // verify event emitted by Dispatcher
             vm.expectEmit(true, true, true, true);
             emit WriteAckPacket(address(v2.ucHandler), channelId2, packetSeq, ackPacket);
-            v2.dispatcherProxy.recvPacket(v2.ucHandler, recvPacket, validProof);
+            v2.dispatcherProxy.recvPacket(recvPacket, validProof);
 
             // verify packet received by Earth on chain B
             (gotChannelId, gotUcPacket) = v2.earth.recvedPackets(packetSeq - 1);
@@ -420,7 +420,7 @@ contract UniversalChannelPacketTest is Base, IbcMwEventsEmitter {
             vm.expectEmit(true, true, true, true);
             emit Acknowledgement(address(v1.ucHandler), channelId1, packetSeq);
             // receive ack on chain A, triggering expected events
-            v1.dispatcherProxy.acknowledgement(v1.ucHandler, recvPacket, ackToBytes(ackPacket), validProof);
+            v1.dispatcherProxy.acknowledgement(recvPacket, ackToBytes(ackPacket), validProof);
 
             // verify ack packet received by Earth on chain A
             (gotChannelId, gotUcPacket, gotAckPacket) = v1.earth.ackPackets(packetSeq - 1);

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -6,7 +6,7 @@ import {Dispatcher} from "../contracts/core/Dispatcher.sol";
 import {IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
 import {IbcReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 import "../contracts/core/UniversalChannelHandler.sol";
-import "../contracts/examples/Mars.sol";
+import {Mars} from "../contracts/examples/Mars.sol";
 import "../contracts/interfaces/IbcMiddleware.sol";
 import "../contracts/core/OpLightClient.sol";
 import "./Dispatcher.base.t.sol";

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -10,7 +10,7 @@ import {ChannelHandshakeTestSuite, ChannelHandshakeTest, ChannelHandshakeUtils} 
 import {LocalEnd} from "../Dispatcher.base.t.sol";
 import {Base, ChannelHandshakeSetting} from "../Dispatcher.base.t.sol";
 import {
-    CounterParty,
+    ChannelEnd,
     ChannelOrder,
     IbcEndpoint,
     IbcPacket,
@@ -59,7 +59,7 @@ contract ChannelHandShakeUpgradeUtil is ChannelHandshakeUtils {
         for (uint256 i = 0; i < settings.length; i++) {
             for (uint256 j = 0; j < versions.length; j++) {
                 LocalEnd memory le = _local;
-                CounterParty memory re = _remote;
+                ChannelEnd memory re = _remote;
                 le.versionCall = versions[j];
                 le.versionExpected = versions[j];
                 re.version = versions[j];
@@ -122,7 +122,7 @@ contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils 
         mars = new Mars(dispatcherProxy);
         portId = IbcUtils.addressToPortId(portPrefix, address(mars));
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
-        _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
+        _remote = ChannelEnd("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
 
         LightClient newLightClient = opLightClient;
         // Add state to test if impacted by upgrade

--- a/test/upgradeableProxy/Dispatcher.upgrade.t.sol
+++ b/test/upgradeableProxy/Dispatcher.upgrade.t.sol
@@ -10,7 +10,14 @@ import {ChannelHandshakeTestSuite, ChannelHandshakeTest, ChannelHandshakeUtils} 
 import {LocalEnd} from "../Dispatcher.base.t.sol";
 import {Base, ChannelHandshakeSetting} from "../Dispatcher.base.t.sol";
 import {
-    CounterParty, ChannelOrder, IbcEndpoint, IbcPacket, AckPacket, Ibc, Height
+    CounterParty,
+    ChannelOrder,
+    IbcEndpoint,
+    IbcPacket,
+    AckPacket,
+    Ibc,
+    IbcUtils,
+    Height
 } from "../../contracts/libs/Ibc.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
@@ -113,6 +120,7 @@ contract DispatcherUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils 
     function setUp() public override {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix, dummyConsStateManager);
         mars = new Mars(dispatcherProxy);
+        portId = IbcUtils.addressToPortId(portPrefix, address(mars));
         _local = LocalEnd(mars, portId, "channel-1", connectionHops, "1.0", "1.0");
         _remote = CounterParty("eth2.7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "channel-2", "1.0");
 

--- a/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
+++ b/test/upgradeableProxy/DispatcherUUPS.accessControl.t.sol
@@ -5,7 +5,7 @@ import "../../contracts/libs/Ibc.sol";
 import {Dispatcher} from "../../contracts/core/Dispatcher.sol";
 import {IbcEventsEmitter} from "../../contracts/interfaces/IbcDispatcher.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
-import "../../contracts/examples/Mars.sol";
+import {Mars} from "../../contracts/examples/Mars.sol";
 import "../../contracts/core/OpLightClient.sol";
 import "../Dispatcher.base.t.sol";
 import {DispatcherV2} from "./upgrades/DispatcherV2.sol";

--- a/test/upgradeableProxy/upgrades/DispatcherV2.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2.sol
@@ -102,7 +102,6 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenInit(
-        IbcChannelReceiver receiver,
         string calldata version,
         ChannelOrder ordering,
         bool feeEnabled,
@@ -113,16 +112,15 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
             revert IBCErrors.invalidCounterPartyPortId();
         }
 
-        (bool success, bytes memory data) = _callIfContract(
-            address(receiver), abi.encodeWithSelector(IbcChannelReceiver.onChanOpenInit.selector, version)
-        );
+        (bool success, bytes memory data) =
+            _callIfContract(msg.sender, abi.encodeWithSelector(IbcChannelReceiver.onChanOpenInit.selector, version));
 
         if (success) {
             emit ChannelOpenInit(
-                address(receiver), abi.decode(data, (string)), ordering, feeEnabled, connectionHops, counterpartyPortId
+                msg.sender, abi.decode(data, (string)), ordering, feeEnabled, connectionHops, counterpartyPortId
             );
         } else {
-            emit ChannelOpenInitError(address(receiver), data);
+            emit ChannelOpenInitError(msg.sender, data);
         }
     }
 

--- a/test/upgradeableProxy/upgrades/DispatcherV2.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2.sol
@@ -12,7 +12,7 @@ import {LightClient} from "../../../contracts/interfaces/LightClient.sol";
 import {IDispatcher} from "../../../contracts/interfaces/IDispatcher.sol";
 import {
     Channel,
-    CounterParty,
+    ChannelEnd,
     ChannelOrder,
     IbcPacket,
     ChannelState,
@@ -130,11 +130,11 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * will be relayed to the  IBC/VIBC hub chain.
      */
     function channelOpenTry(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         ChannelOrder ordering,
         bool feeEnabled,
         string[] calldata connectionHops,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         if (bytes(counterparty.portId).length == 0) {
@@ -172,11 +172,11 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * The dApp should implement the onChannelConnect method to handle the third channel handshake method: ChanOpenAck
      */
     function channelOpenAck(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         _lightClient.verifyMembership(
@@ -205,11 +205,11 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
      * ChannelOpenConfirm
      */
     function channelOpenConfirm(
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty,
+        ChannelEnd calldata counterparty,
         Ics23Proof calldata proof
     ) external {
         _lightClient.verifyMembership(
@@ -549,11 +549,11 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
 
     function _connectChannel(
         IbcChannelReceiver portAddress,
-        CounterParty calldata local,
+        ChannelEnd calldata local,
         string[] calldata connectionHops,
         ChannelOrder ordering,
         bool feeEnabled,
-        CounterParty calldata counterparty
+        ChannelEnd calldata counterparty
     ) internal {
         // Register port and channel mapping
         // TODO: check duplicated channel registration?

--- a/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
@@ -13,10 +13,10 @@ import {LightClient} from "../../../contracts/interfaces/LightClient.sol";
  */
 
 contract DispatcherV2Initializable is DispatcherV2 {
-    function initialize(string memory initPortPrefix, LightClient _lightClient) public override reinitializer(2) {
+    function initialize(string memory initPortPrefix, LightClient lightClient) public override reinitializer(2) {
         __Ownable_init();
         portPrefix = initPortPrefix;
         portPrefixLen = uint32(bytes(initPortPrefix).length);
-        lightClient = _lightClient;
+        _lightClient = lightClient;
     }
 }


### PR DESCRIPTION
PR to change the dispatcher handshake methods to use msg.sender and counterparty portID for channel callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `openChannel` function for initiating channel openings, enhancing communication flexibility.
	- Added a `triggerChannelInit` function allowing owners to start the channel opening process.
- **Refactor**
	- Streamlined channel communication by removing the `IbcChannelReceiver` parameter and using `msg.sender` for direct interactions.
	- Simplified method signatures across interfaces for improved clarity and interaction.
- **Chores**
	- Updated file system permissions and removed unused configurations for a cleaner setup.
	- Adjusted import statements and test configurations for better code management and testing practices.
- **Style**
	- Made variable visibility and naming adjustments in upgradeable proxy tests for clearer code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->