### PR TITLE
fix writeTimeoutPacket vuln

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -454,23 +454,6 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
         emit WriteAckPacket(receiver, packet.dest.channelId, packet.sequence, ack);
     }
 
-    // TODO: add async writeAckPacket
-    // // this can be invoked sync or async by the IBC-dApp
-    // function writeAckPacket(IbcPacket calldata packet, AckPacket calldata ackPacket) external {
-    //     // verify `receiver` is the original packet sender
-    //     require(
-    //         portIdAddressMatch(address(msg.sender), packet.src.portId),
-    //         'Receiver is not the original packet sender'
-    //     );
-    // }
-
-    // TODO: remove below writeTimeoutPacket() function
-    //       1. core SC is responsible to generate timeout packet
-    //       2. user contract are not free to generate timeout with different criteria
-    //       3. [optional]: we may wish relayer to trigger timeout process, but in this case, belowunction won't do
-    // the job, as it doesn't have proofs.
-    //          There is no strong reason to do this, as relayer can always do the regular `recvPacket` flow, which will
-    // do proper timeout generation.
     /**
      * Generate a timeout packet for the given packet
      */
@@ -516,16 +499,6 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     {
         return _lightClient.getState(height);
     }
-
-    // verify an EVM address matches an IBC portId.
-    // IBC_PortID = portPrefix + address (hex string without 0x prefix, case-insensitive)
-    // function portIdAddressMatch(address addr, string calldata portId) public view returns (bool isMatch) {
-    //     if (keccak256(abi.encodePacked(portPrefix)) != keccak256(abi.encodePacked(portId[0:portPrefixLen]))) {
-    //         return false;
-    //     }
-    //     string memory portSuffix = portId[portPrefixLen:];
-    //     isMatch = Ibc._hexStrToAddress(portSuffix) == addr;
-    // }
 
     // Prerequisite: must verify sender is authorized to send packet on the channel
     function _sendPacket(address sender, bytes32 channelId, bytes memory packet, uint64 timeoutTimestamp) internal {

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -474,7 +474,11 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     /**
      * Generate a timeout packet for the given packet
      */
-    function writeTimeoutPacket(IbcPacket calldata packet) external {
+    function writeTimeoutPacket(IbcPacket calldata packet, Ics23Proof calldata proof) external {
+        _lightClient.verifyMembership(
+            proof, Ibc.packetCommitmentProofKey(packet), abi.encode(Ibc.packetCommitmentProofValue(packet))
+        );
+
         address receiver = _getAddressFromPort(packet.src.portId);
         // verify packet does not have a receipt
         bool hasReceipt = _recvPacketReceipt[receiver][packet.dest.channelId][packet.sequence];

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -89,6 +89,8 @@ interface IDispatcher is IbcDispatcher, IbcEventsEmitter {
 
     function timeout(IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
+    function writeTimeoutPacket(IbcPacket calldata packet, Ics23Proof calldata proof) external;
+
     function recvPacket(IbcPacket calldata packet, Ics23Proof calldata proof) external;
 
     function getOptimisticConsensusState(uint256 height)

--- a/test/Dispatcher.proof.t.sol
+++ b/test/Dispatcher.proof.t.sol
@@ -145,7 +145,7 @@ contract DispatcherIbcWithRealProofs is DispatcherIbcWithRealProofsSuite {
         (dispatcherProxy, dispatcherImplementation) = deployDispatcherProxyAndImpl(portPrefix1, consensusStateManager);
 
         address targetMarsAddress = 0x71C95911E9a5D330f4D621842EC243EE1343292e;
-        deployCodeTo("Mars.sol", abi.encode(address(dispatcherProxy)), targetMarsAddress);
+        deployCodeTo("Mars.sol:Mars", abi.encode(address(dispatcherProxy)), targetMarsAddress);
         mars = Mars(payable(targetMarsAddress));
 
         portId1 = "polyibc.eth1.71C95911E9a5D330f4D621842EC243EE1343292e";

--- a/test/upgradeableProxy/upgrades/DispatcherV2.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2.sol
@@ -473,15 +473,15 @@ contract DispatcherV2 is OwnableUpgradeable, UUPSUpgradeable, IDispatcher {
     /**
      * Generate a timeout packet for the given packet
      */
-    function writeTimeoutPacket(IbcPacket calldata packet) external {
-        // verify `receiver` is the original packet sender
-        // if (!portIdAddressMatch(receiver, packet.src.portId)) {
-        //     revert IBCErrors.receiverNotIntendedPacketDestination();
-        // }
+    function writeTimeoutPacket(IbcPacket calldata packet, Ics23Proof calldata proof) external {
+        _lightClient.verifyMembership(
+            proof, Ibc.packetCommitmentProofKey(packet), abi.encode(Ibc.packetCommitmentProofValue(packet))
+        );
 
-        address receiver = _getAddressFromPort(packet.dest.portId);
+        address receiver = _getAddressFromPort(packet.src.portId);
         // verify packet does not have a receipt
         bool hasReceipt = _recvPacketReceipt[receiver][packet.dest.channelId][packet.sequence];
+
         if (hasReceipt) {
             revert IBCErrors.packetReceiptAlreadyExists();
         }


### PR DESCRIPTION
Quick PR to fix the vuln in writetimeoutpacket to check for proofs before writing a timeout. Since we're checking for a proof of the packet existing in the ibc state, an arbitrary packet with only the timeout changed cannot be spoofed now. 

Note that this doesn't patch the vuln for channels which use the dummy light client, though this seems to be expected that these channels in general are not secure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced security for packet processing in the Dispatcher contract by requiring an additional verification proof (`Ics23Proof`).
  
- **Tests**
  - Added a new test to validate the prevention of packet spoofing in timeout scenarios.

- **Refactor**
  - Updated the `writeTimeoutPacket` function across contracts and interfaces to include proof verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->