### PR TITLE
Raunak/upgradeable uch

### DIFF
--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -191,6 +191,10 @@ contract UniversalChannelHandler is IbcReceiverBaseUpgradeable, IbcUniversalChan
 
     function onChanOpenConfirm(bytes32 channelId) external onlyIbcDispatcher {}
 
+    function setDispatcher(IbcDispatcher _dispatcher) external onlyOwner {
+        dispatcher = _dispatcher;
+    }
+
     function _connectChannel(bytes32 channelId, string calldata version)
         internal
         returns (string memory checkedVersion)

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -11,10 +11,13 @@ import {
     IbcMwPacketReceiver,
     IbcMwEventsEmitter
 } from "../interfaces/IbcMiddleware.sol";
-import {IbcReceiver, IbcReceiverBase} from "../interfaces/IbcReceiver.sol";
+import {IbcReceiver} from "../interfaces/IbcReceiver.sol";
+import {IbcReceiverBaseUpgradeable} from "../interfaces/IbcReceiverUpgradeable.sol";
 import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket, UniversalPacket, IbcUtils} from "../libs/Ibc.sol";
 
-contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
+contract UniversalChannelHandler is IbcReceiverBaseUpgradeable, IbcUniversalChannelMW {
+    uint256[49] private __gap;
+
     bytes32[] public connectedChannels;
     string public constant VERSION = "1.0";
     uint256 public constant MW_ID = 1;
@@ -24,7 +27,13 @@ contract UniversalChannelHandler is IbcReceiverBase, IbcUniversalChannelMW {
 
     event UCHPacketSent(address source, bytes32 destination);
 
-    constructor(IbcDispatcher _dispatcher) IbcReceiverBase(_dispatcher) {}
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(IbcDispatcher _dispatcher) public initializer {
+        __IbcReceiverBase_init(_dispatcher);
+    }
     /**
      * @dev Close a universal channel.
      * Cannot send or receive packets after the channel is closed.

--- a/contracts/interfaces/IUniversalChannelHandler.sol
+++ b/contracts/interfaces/IUniversalChannelHandler.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IbcDispatcher, IbcEventsEmitter} from "./IbcDispatcher.sol";
+
+import {L1Header, OpL2StateProof, Ics23Proof} from "./ProofVerifier.sol";
+import {IbcUniversalChannelMW} from "./IbcMiddleware.sol";
+import {
+    Channel,
+    ChannelEnd,
+    ChannelOrder,
+    IbcPacket,
+    ChannelState,
+    AckPacket,
+    IBCErrors,
+    IbcUtils,
+    Ibc
+} from "../libs/Ibc.sol";
+
+interface IUniversalChannelHandler is IbcUniversalChannelMW {
+    function registerMwStack(uint256 mwBitmap, address[] calldata mwAddrs) external;
+    function openChannel(
+        string calldata version,
+        ChannelOrder ordering,
+        bool feeEnabled,
+        string[] calldata connectionHops,
+        string calldata counterpartyPortIdentifier
+    ) external;
+    function closeChannel(bytes32 channelId) external;
+    function connectedChannels(uint256) external view returns (bytes32);
+}

--- a/contracts/interfaces/IUniversalChannelHandler.sol
+++ b/contracts/interfaces/IUniversalChannelHandler.sol
@@ -27,5 +27,7 @@ interface IUniversalChannelHandler is IbcUniversalChannelMW {
         string calldata counterpartyPortIdentifier
     ) external;
     function closeChannel(bytes32 channelId) external;
-    function connectedChannels(uint256) external view returns (bytes32);
+    function setDispatcher(IbcDispatcher dispatcher) external;
+    function dispatcher() external returns (IbcDispatcher dispatcher);
+    function connectedChannels(uint256) external view returns (bytes32 channel);
 }

--- a/contracts/interfaces/IbcReceiverUpgradeable.sol
+++ b/contracts/interfaces/IbcReceiverUpgradeable.sol
@@ -1,0 +1,45 @@
+//SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.9;
+
+import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import {IbcDispatcher} from "./IbcDispatcher.sol";
+import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket} from "../libs/Ibc.sol";
+
+contract IbcReceiverBaseUpgradeable is OwnableUpgradeable {
+    IbcDispatcher public dispatcher;
+
+    error notIbcDispatcher();
+    error UnsupportedVersion();
+    error ChannelNotFound();
+
+    /**
+     * @dev Modifier to restrict access to only the IBC dispatcher.
+     * Only the address with the IBC_ROLE can execute the function.
+     * Should add this modifier to all IBC-related callback functions.
+     */
+    modifier onlyIbcDispatcher() {
+        if (msg.sender != address(dispatcher)) {
+            revert notIbcDispatcher();
+        }
+        _;
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @dev initializer function that takes an IbcDispatcher address and grants the IBC_ROLE to the Polymer IBC
+     * Dispatcher.
+     * @param _dispatcher The address of the IbcDispatcher contract.
+     */
+    function __IbcReceiverBase_init(IbcDispatcher _dispatcher) internal onlyInitializing {
+        __Ownable_init();
+        dispatcher = _dispatcher;
+    }
+
+    /// This function is called for plain Ether transfers, i.e. for every call with empty calldata.
+    // An empty function body is sufficient to receive packet fee refunds.
+    receive() external payable {}
+}

--- a/contracts/interfaces/IbcReceiverUpgradeable.sol
+++ b/contracts/interfaces/IbcReceiverUpgradeable.sol
@@ -29,6 +29,10 @@ contract IbcReceiverBaseUpgradeable is OwnableUpgradeable {
         _disableInitializers();
     }
 
+    /// This function is called for plain Ether transfers, i.e. for every call with empty calldata.
+    // An empty function body is sufficient to receive packet fee refunds.
+    receive() external payable {}
+
     /**
      * @dev initializer function that takes an IbcDispatcher address and grants the IBC_ROLE to the Polymer IBC
      * Dispatcher.
@@ -38,8 +42,4 @@ contract IbcReceiverBaseUpgradeable is OwnableUpgradeable {
         __Ownable_init();
         dispatcher = _dispatcher;
     }
-
-    /// This function is called for plain Ether transfers, i.e. for every call with empty calldata.
-    // An empty function body is sufficient to receive packet fee refunds.
-    receive() external payable {}
 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -7,6 +7,7 @@ import "../contracts/utils/DummyLightClient.sol";
 import "../contracts/core/Dispatcher.sol";
 import {Mars} from "../contracts/examples/Mars.sol";
 import {IDispatcher} from "../contracts/core/Dispatcher.sol";
+import {IUniversalChannelHandler} from "../contracts/interfaces/IUniversalChannelHandler.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import "../contracts/core/OpProofVerifier.sol";
 import "../contracts/core/OpLightClient.sol";
@@ -106,9 +107,18 @@ contract Deploy is Script {
     }
 
     function deployUniversalChannelHandler(address dispatcher) public broadcast returns (address addr_) {
-        UniversalChannelHandler handler = new UniversalChannelHandler{salt: _implSalt()}(IbcDispatcher(dispatcher));
-        console.log("UniversalChannelHandler deployed at %s", address(handler));
-        return address(handler);
+        UniversalChannelHandler uchImplementation = new UniversalChannelHandler();
+        IUniversalChannelHandler proxy = IUniversalChannelHandler(
+            address(
+                new ERC1967Proxy(
+                    address(uchImplementation),
+                    abi.encodeWithSelector(UniversalChannelHandler.initialize.selector, dispatcher)
+                )
+            )
+        );
+        console.log("UniversalChannelHandler implementation deployed at %s", address(uchImplementation));
+        console.log("UniversalChannelHandler proxy deployed at %s", address(proxy));
+        return address(proxy);
     }
 
     function deployEarth(address middleware) public broadcast returns (address addr_) {

--- a/test/TestUtils.t.sol
+++ b/test/TestUtils.t.sol
@@ -1,11 +1,12 @@
 import {IDispatcher} from "../contracts/interfaces/IDispatcher.sol";
+import {IUniversalChannelHandler} from "../contracts/interfaces/IUniversalChannelHandler.sol";
 import {LightClient} from "../contracts/interfaces/LightClient.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
-// import {StdCheats} from "../forge-std/StdCheats.sol";
+import {UniversalChannelHandler} from "../contracts/core/UniversalChannelHandler.sol";
+
 import {Test} from "forge-std/Test.sol";
 import {Vm} from "forge-std/Vm.sol";
-// import {StdCheats} from "forge-std/StdCheats.sol";
 
 pragma solidity ^0.8.0;
 
@@ -24,6 +25,21 @@ abstract contract TestUtilsTest {
                 new ERC1967Proxy(
                     address(dispatcherImplementation),
                     abi.encodeWithSelector(Dispatcher.initialize.selector, initPortPrefix, lightClient)
+                )
+            )
+        );
+    }
+
+    function deployUCHProxyAndImpl(address dispatcherProxy)
+        public
+        returns (IUniversalChannelHandler proxy, UniversalChannelHandler uchImplementation)
+    {
+        uchImplementation = new UniversalChannelHandler();
+        proxy = IUniversalChannelHandler(
+            address(
+                new ERC1967Proxy(
+                    address(uchImplementation),
+                    abi.encodeWithSelector(UniversalChannelHandler.initialize.selector, dispatcherProxy)
                 )
             )
         );


### PR DESCRIPTION
PR to make UCH upgradeable + add a setter in the UCH to upgrade the dispatcher contract to give us the most flexibility over upgrades.

Though we've previously discussed adding unimplemented methods as placeholders for when we implement channelClose - after discussing with @dshiell we came to the conclusion they don't bring a whole lot, since the current channel close handlers are called `closeIbcChannel`, and will soon be renamed to `chanCloseInit` and `chanCloseConfirm` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced an interface for handling universal channels in Inter-Blockchain Communication, including middleware registration and channel management.
    - Added an initialization function and a `setDispatcher` function for enhanced control over channel handling.

- **Refactor**
    - Updated the deployment process to use a proxy pattern, increasing modularity and flexibility.
    - Adjusted channel handling logic and related function calls to align with new interface implementations.

- **Tests**
    - Updated test scripts to incorporate new interface and proxy usage, ensuring consistency and functionality across test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->