### PR TITLE
Raunak/reentrancy guard patch

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -62,7 +62,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
      * @dev This method should be called only once during contract deployment.
      * @dev For contract upgarades, which need to reinitialize the contract, use the reinitializer modifier.
      */
-    function initialize(string memory initPortPrefix) public virtual initializer {
+    function initialize(string memory initPortPrefix) public virtual initializer nonReentrant {
         if (bytes(initPortPrefix).length == 0) {
             revert IBCErrors.invalidPortPrefix();
         }


### PR DESCRIPTION
PR to initialize the _status variable 

normally we should inherit from the [ReentrancyGuardUpgradeable](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/f55babcbeef1d1c42c8e0f8884abcd6663a7909f/contracts/security/ReentrancyGuardUpgradeable.sol) contract (this was an oversight on my part) but since that contract has minimal changes from the normal ReentrancyGuard contract we're currently inheriting from in the Dispatcher, we can just use the nomal contract, but add the `nonReentrant` modifier to the init function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security by adding a `nonReentrant` modifier to the initialization function in the Dispatcher contract.
- **Refactor**
	- Simplified function names and streamlined inheritance in test contracts to improve clarity and maintainability.
- **Tests**
	- Introduced new tests to ensure contract stability and state preservation during upgrades.
- **Documentation**
	- Updated documentation to reflect changes in contract functionalities and testing approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->