### PR TITLE
remove mw functionaity from uch

### DIFF
--- a/contracts/base/GeneralMiddleware.sol
+++ b/contracts/base/GeneralMiddleware.sol
@@ -35,7 +35,7 @@ import {
  *  @notice GeneralMiddleware is a starting point for developers to implement their own middleware logic. It is not
  * intended to be directly deployed, but rather only used for testing and development
  */
-contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter {
+contract GeneralMiddleware is IbcMwUser, IbcMiddleware, IbcMwEventsEmitter, IbcMwPacketSender {
     /**
      * @dev MW_ID is the ID of MW contract on all supported virtual chains.
      * MW_ID must:

--- a/contracts/interfaces/IbcMiddleware.sol
+++ b/contracts/interfaces/IbcMiddleware.sol
@@ -99,7 +99,7 @@ interface IbcUniversalPacketReceiver {
     function onTimeoutUniversalPacket(bytes32 channelId, UniversalPacket calldata packet) external;
 }
 
-interface IbcMiddlwareProvider is IbcUniversalPacketSender, IbcMwPacketSender {
+interface IbcMiddlwareProvider is IbcUniversalPacketSender {
     /**
      * @dev MW_ID is the ID of MW contract on all supported virtual chains.
      * MW_ID must:

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -210,12 +210,14 @@ contract UniversalChannelPacketTest is Base, IbcMwEventsEmitter {
 
     // packet flow: Earth -> MW1 -> UC -> Dispatcher -> (Relayer) -> Dispatcher -> UC -> MW1 -> Earth
     function test_packetFlow_via_mw1_ok() public {
+        vm.skip(true); // uch as middleware sender is not yet supported
         uint256 mwBitmap = register_mw1();
         verifyPacketFlow(5, mwBitmap);
     }
 
     // packet flow: Earth -> MW1 -> MW2 -> UC -> Dispatcher -> (Relayer) -> Dispatcher -> UC -> MW2 -> MW1 -> Earth
     function test_packetFlow_via_mw2_ok() public {
+        vm.skip(true); // uch as middleware sender is not yet supported
         uint256 mwBitmap = register_mw1_mw2();
         verifyPacketFlow(5, mwBitmap);
     }


### PR DESCRIPTION
PR to remove mw functionality from the UCH to simply uch logic. this should be backwards compatible the uch currently deployed on testnet and should allow us to do a UUPS upgrade 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `IbcMwPacketSender` interface to improve middleware communication capabilities.

- **Refactor**
	- Simplified the middleware handling by removing specific middleware stack addresses and functions related to middleware packet sending in the `UniversalChannelHandler`.
	- Removed inheritance of `IbcMwPacketSender` from `IbcMiddlewareProvider` to streamline interface relationships.

- **Tests**
	- Adjusted tests to skip certain middleware sender scenarios reflecting the current support limitations in middleware handling.

- **Bug Fixes**
	- Updated logic in packet reception and middleware handling to enhance reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->