### PR TITLE
add channelid and port information in dispatcher proxy error events

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -181,7 +181,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
                 msg.sender, abi.decode(data, (string)), ordering, feeEnabled, connectionHops, counterpartyPortId
             );
         } else {
-            emit ChannelOpenInitError(msg.sender, data);
+            emit ChannelOpenInitError(msg.sender, data, counterpartyPortId);
         }
     }
 
@@ -252,7 +252,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
                 counterparty.channelId
             );
         } else {
-            emit ChannelOpenTryError(receiver, data);
+            emit ChannelOpenTryError(receiver, data, local.portId, local.channelId);
         }
     }
 
@@ -312,7 +312,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
             _connectChannel(IbcChannelReceiver(receiver), local, connectionHops, ordering, feeEnabled, counterparty);
             emit ChannelOpenAck(receiver, local.channelId);
         } else {
-            emit ChannelOpenAckError(receiver, data);
+            emit ChannelOpenAckError(receiver, data, local.portId, local.channelId);
         }
     }
 
@@ -372,7 +372,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
             _connectChannel(IbcChannelReceiver(receiver), local, connectionHops, ordering, feeEnabled, counterparty);
             emit ChannelOpenConfirm(receiver, local.channelId);
         } else {
-            emit ChannelOpenConfirmError(receiver, data);
+            emit ChannelOpenConfirmError(receiver, data, local.portId, local.channelId);
         }
     }
 
@@ -404,7 +404,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
         if (success) {
             emit ChannelCloseInit(msg.sender, channelId);
         } else {
-            emit ChannelCloseInitError(address(msg.sender), data);
+            emit ChannelCloseInitError(address(msg.sender), data, channelId);
         }
     }
 
@@ -462,7 +462,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
         if (success) {
             emit ChannelCloseConfirm(portAddress, channelId);
         } else {
-            emit ChannelCloseConfirmError(address(portAddress), data);
+            emit ChannelCloseConfirmError(address(portAddress), data, channelId);
         }
     }
 
@@ -530,7 +530,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
             delete _sendPacketCommitment[receiver][packet.src.channelId][packet.sequence];
             emit Acknowledgement(receiver, packet.src.channelId, packet.sequence);
         } else {
-            emit AcknowledgementError(receiver, data);
+            emit AcknowledgementError(receiver, data, packet.src.channelId, packet.sequence);
         }
     }
 

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -68,7 +68,7 @@ interface IbcEventsEmitter {
         string[] connectionHops,
         string counterpartyPortId
     );
-    event ChannelOpenInitError(address indexed receiver, bytes error);
+    event ChannelOpenInitError(address indexed receiver, bytes error, string counterpartyPortId);
 
     event ChannelOpenTry(
         address indexed receiver,
@@ -79,20 +79,22 @@ interface IbcEventsEmitter {
         string counterpartyPortId,
         bytes32 counterpartyChannelId
     );
-    event ChannelOpenTryError(address indexed receiver, bytes error);
+    event ChannelOpenTryError(address indexed receiver, bytes error, string localPortId, bytes32 counterpartyPortId);
 
     event ChannelOpenAck(address indexed receiver, bytes32 channelId);
-    event ChannelOpenAckError(address indexed receiver, bytes error);
+    event ChannelOpenAckError(address indexed receiver, bytes error, string localPortId, bytes32 localChannelId);
 
     event ChannelOpenConfirm(address indexed receiver, bytes32 channelId);
-    event ChannelOpenConfirmError(address indexed receiver, bytes error);
+    event ChannelOpenConfirmError(
+        address indexed receiver, bytes error, string localPortId, bytes32 counterpartyPortId
+    );
 
     event ChannelCloseInit(address indexed portAddress, bytes32 indexed channelId);
     event ChannelCloseConfirm(address indexed portAddress, bytes32 indexed channelId);
 
-    event ChannelCloseInitError(address indexed receiver, bytes error);
-    event ChannelCloseConfirmError(address indexed receiver, bytes error);
-    event AcknowledgementError(address indexed receiver, bytes error);
+    event ChannelCloseInitError(address indexed receiver, bytes error, bytes32 channelId);
+    event ChannelCloseConfirmError(address indexed receiver, bytes error, bytes32 channelId);
+    event AcknowledgementError(address indexed receiver, bytes error, bytes32 channelId, uint64 sequence);
     event TimeoutError(address indexed receiver, bytes error);
 
     //

--- a/test/Dispatcher/Dispatcher.closeChannel.t.sol
+++ b/test/Dispatcher/Dispatcher.closeChannel.t.sol
@@ -105,7 +105,8 @@ contract DappRevertTestsCloseChannel is DappHandlerRevertTests {
         vm.expectEmit(true, true, true, true);
         emit ChannelCloseInitError(
             address(revertingStringCloseMars),
-            abi.encodeWithSignature("Error(string)", "close ibc channel is reverting")
+            abi.encodeWithSignature("Error(string)", "close ibc channel is reverting"),
+            _local.channelId
         );
         revertingStringCloseMars.triggerChannelClose(ch0.channelId);
 
@@ -120,7 +121,8 @@ contract DappRevertTestsCloseChannel is DappHandlerRevertTests {
         vm.expectEmit(true, true, true, true);
         emit ChannelCloseConfirmError(
             address(revertingStringCloseMars),
-            abi.encodeWithSignature("Error(string)", "close ibc channel is reverting")
+            abi.encodeWithSignature("Error(string)", "close ibc channel is reverting"),
+            ch0.channelId
         );
 
         dispatcherProxy.channelCloseConfirm(address(revertingStringCloseMars), ch0.channelId, validProof);

--- a/test/Dispatcher/Dispatcher.dappHandlerRevert.t.sol
+++ b/test/Dispatcher/Dispatcher.dappHandlerRevert.t.sol
@@ -34,13 +34,13 @@ contract DappHandlerRevertTests is Base {
     function test_ibc_channel_open_non_dapp_call() public {
         address nonDappAddr = vm.addr(1);
 
-        emit ChannelOpenInitError(nonDappAddr, bytes("call to non-contract"));
+        emit ChannelOpenInitError(nonDappAddr, bytes("call to non-contract"), ch0.portId);
         dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
 
     function test_ibc_channel_open_dapp_without_handler() public {
         Earth earth = new Earth(vm.addr(1));
-        emit ChannelOpenInitError(address(earth), "");
+        emit ChannelOpenInitError(address(earth), "", ch0.portId);
         dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
 
@@ -126,7 +126,9 @@ contract DappHandlerRevertTests is Base {
         vm.expectEmit(true, true, true, true);
         emit AcknowledgementError(
             address(revertingStringMars),
-            abi.encodeWithSignature("Error(string)", "acknowledgement packet is reverting")
+            abi.encodeWithSignature("Error(string)", "acknowledgement packet is reverting"),
+            packet.src.channelId,
+            packet.sequence
         );
         dispatcherProxy.acknowledgement(packet, ack, validProof);
     }
@@ -135,7 +137,9 @@ contract DappHandlerRevertTests is Base {
         vm.expectEmit(true, true, true, true);
         vm.prank(address(revertingStringMars));
         emit ChannelOpenInitError(
-            address(revertingStringMars), abi.encodeWithSignature("Error(string)", "open ibc channel is reverting")
+            address(revertingStringMars),
+            abi.encodeWithSignature("Error(string)", "open ibc channel is reverting"),
+            ch0.portId
         );
         dispatcherProxy.channelOpenInit(ch1.version, ChannelOrder.NONE, false, connectionHops1, ch0.portId);
     }
@@ -144,7 +148,10 @@ contract DappHandlerRevertTests is Base {
         vm.expectEmit(true, true, true, true);
         ch0.portId = IbcUtils.addressToPortId(portPrefix, address(revertingStringMars));
         emit ChannelOpenAckError(
-            address(revertingStringMars), abi.encodeWithSignature("Error(string)", "connect ibc channel is reverting")
+            address(revertingStringMars),
+            abi.encodeWithSignature("Error(string)", "connect ibc channel is reverting"),
+            ch0.portId,
+            ch0.channelId
         );
         dispatcherProxy.channelOpenAck(ch0, connectionHops0, ChannelOrder.NONE, false, ch1, validProof);
     }

--- a/test/Dispatcher/Dispatcher.t.sol
+++ b/test/Dispatcher/Dispatcher.t.sol
@@ -115,7 +115,7 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
                 le.versionExpected = versions[j];
                 vm.expectEmit(true, true, true, true);
                 emit IbcEventsEmitter.ChannelOpenInitError(
-                    address(le.receiver), abi.encodeWithSelector(IbcReceiverBase.UnsupportedVersion.selector)
+                    address(le.receiver), abi.encodeWithSelector(IbcReceiverBase.UnsupportedVersion.selector), re.portId
                 );
                 channelOpenInit(le, re, settings[i], false);
             }
@@ -152,7 +152,10 @@ abstract contract ChannelHandshakeTestSuite is ChannelHandshakeUtils {
                 re.version = versions[j];
                 vm.expectEmit(true, true, true, true);
                 emit IbcEventsEmitter.ChannelOpenAckError(
-                    address(le.receiver), abi.encodeWithSelector(IbcReceiverBase.UnsupportedVersion.selector)
+                    address(le.receiver),
+                    abi.encodeWithSelector(IbcReceiverBase.UnsupportedVersion.selector),
+                    le.portId,
+                    le.channelId
                 );
 
                 channelOpenAck(le, re, settings[i], false);


### PR DESCRIPTION
PR to respond to the issue to make errors emitted in the dispatcher contain information like channeld and portId that can be used to track which packet/channel caused the error. 

Previously, we couldn't implement this because the contract size was too large, and adding events increased it over the size limit. But now since we have gotten rid of the timeout implementation, we have some more size to work with, and can include these changes in mainnet launch to make things easier on the indexer, if we want. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced event logging in smart contracts to include additional parameters such as `counterpartyPortId`, `localPortId`, `localChannelId`, and `channelId` for better context in channel operations.

- **Refactor**
  - Updated event emissions and error message encodings across various contracts to reflect new parameter inclusions, improving traceability and debugging capabilities.

- **Tests**
  - Modified test cases to align with the updated event parameter requirements, ensuring consistency and reliability in contract behavior validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->