### PR TITLE
channel-open-init: fix typo in event field

### DIFF
--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -61,7 +61,7 @@ interface IbcEventsEmitter {
     // channel events
     //
     event ChannelOpenInit(
-        address indexed recevier,
+        address indexed receiver,
         string version,
         ChannelOrder ordering,
         bool feeEnabled,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the `ChannelOpenInit` event declaration to ensure accurate spelling of "receiver."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->