### PR TITLE
Raunak/audit fixes 05 2024

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -5,6 +5,7 @@
     "const-name-snakecase": "error",
     "constructor-syntax": "error",
     "no-global-import" : ["error"],
+    "no-unused-import":["error"],
     "custom-errors": ["error"],
     "no-inline-assembly": "off",
     "named-return-values": ["error"],

--- a/contracts/base/GeneralMiddleware.sol
+++ b/contracts/base/GeneralMiddleware.sol
@@ -18,7 +18,7 @@
 
 pragma solidity ^0.8.9;
 
-import {Ibc, UniversalPacket, AckPacket} from "../libs/Ibc.sol";
+import {UniversalPacket, AckPacket} from "../libs/Ibc.sol";
 import {IbcUtils} from "../libs/IbcUtils.sol";
 import {
     IbcUniversalPacketReceiver,

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -148,7 +148,8 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
      * @notice Initializes the channel opening process with the specified parameters. This is the first step in the  channel
      * handshake, initiated directly by the dapp which wishes to establish a channel with the receiver.
      * @param ordering The ordering of the channel (ORDERED or UNORDERED).
-     * @param feeEnabled A boolean indicating whether fees are enabled for the channel.
+     * @param feeEnabled A boolean indicating whether fees are enabled for the channel. Note: This value isn't currently
+     * used
      * @param connectionHops The list of connection hops associated with the channel, with the first channel in this
      * array always starting from the chain this contract is deployed on
      * @param counterpartyPortId The port ID of the counterparty.
@@ -193,7 +194,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
      * chain.
      * @param local The counterparty information for the receiver.
      * @param ordering The ordering of the channel (ORDERED or UNORDERED).
-     * @param feeEnabled Whether fees are enabled for the channel.
+     * @param feeEnabled Whether fees are enabled for the channel. Note: This value isn't currently used
      * @param connectionHops The list of connection hops associated with the channel; with the first channel in this
      * array always starting from the chain this contract is deployed on
      * @param counterparty The counterparty information of the sender
@@ -267,7 +268,8 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
      * @param connectionHops The list of connection hops associated with the channel, with the first channel in this
      * array always starting from the chain this contract is deployed on.
      * @param ordering The ordering of the channel (ORDERED or UNORDERED).
-     * @param feeEnabled A boolean indicating whether fees are enabled for the channel.
+     * @param feeEnabled A boolean indicating whether fees are enabled for the channel. Note: This value isn't currently
+     * used
      * @param counterparty The counterparty information for the channel.
      * @param proof The proof that the counterparty is in the ACK_PENDING state (i.e. that it responded with a
      * successful channelOpenTry )
@@ -702,7 +704,8 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
      * @param connectionHops The connection hops associated with the channel, with the first channel in this
      * array always starting from the chain this contract is deployed on.
      * @param ordering The ordering of the channel.
-     * @param feeEnabled A boolean indicating whether fees are enabled for the channel.
+     * @param feeEnabled A boolean indicating whether fees are enabled for the channel. Note: This value isn't currently
+     * used
      * @param counterparty The details of the counterparty.
      */
     function _connectChannel(
@@ -714,7 +717,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
         ChannelEnd calldata counterparty
     ) internal {
         // We don't need to check that a channel isn't already present between a portAddress and a chanenlId since
-        // polymer chain verification should prevent double registration of the same channel.
+        // polymer chain verification should prevent double registration of the same channel (with the execption of the
+        // feeEnabled state, thoguh this isn't currently used anywhere so change a channel's feeEnabled state shouldn't
+        // have any outcome)
         _portChannelMap[address(portAddress)][local.channelId] = Channel(
             local.version,
             ordering,

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -713,12 +713,10 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
         bool feeEnabled,
         ChannelEnd calldata counterparty
     ) internal {
-        // Register port and channel mapping
-        // TODO: check duplicated channel registration?
-        // TODO: The call to `Channel` constructor MUST be move to `openIbcChannel` phase
-        //       Then `connectIbcChannel` phase can use the `version` as part of `require` condition.
+        // We don't need to check that a channel isn't already present between a portAddress and a chanenlId since
+        // polymer chain verification should prevent double registration of the same channel.
         _portChannelMap[address(portAddress)][local.channelId] = Channel(
-            counterparty.version, // TODO: this should be self version instead of counterparty version
+            local.version,
             ordering,
             feeEnabled,
             connectionHops,

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -27,7 +27,6 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, Ibc} from "../libs/Ibc.sol";
 import {IBCErrors} from "../libs/IbcErrors.sol";
-import {IbcUtils} from "../libs/IbcUtils.sol";
 
 /**
  * @title Dispatcher
@@ -362,8 +361,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
 
         address receiver = _getAddressFromPort(local.portId);
         (bool success, bytes memory data) = _callIfContract(
-            receiver,
-            abi.encodeWithSelector(IbcChannelReceiver.onChanOpenConfirm.selector, local.channelId, counterparty.version)
+            receiver, abi.encodeWithSelector(IbcChannelReceiver.onChanOpenConfirm.selector, local.channelId)
         );
 
         if (success) {

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -640,7 +640,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
             proof, Ibc.packetCommitmentProofKey(packet), abi.encode(Ibc.packetCommitmentProofValue(packet))
         );
 
-        address receiver = _getAddressFromPort(packet.src.portId);
+        address receiver = _getAddressFromPort(packet.dest.portId);
         // verify packet does not have a receipt
         bool hasReceipt = _recvPacketReceipt[receiver][packet.dest.channelId][packet.sequence];
         if (hasReceipt) {

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -27,6 +27,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, Ibc} from "../libs/Ibc.sol";
 import {IBCErrors} from "../libs/IbcErrors.sol";
+import {IbcUtils} from "../libs/IbcUtils.sol";
 
 /**
  * @title Dispatcher
@@ -804,7 +805,7 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
     }
 
     function _getAddressFromPort(string calldata port) internal view returns (address addr) {
-        addr = Ibc._hexStrToAddress(port[portPrefixLen:]);
+        addr = IbcUtils.hexStrToAddress(port[portPrefixLen:]);
     }
 
     /**

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -17,18 +17,16 @@
 
 pragma solidity 0.8.15;
 
-import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {IbcChannelReceiver, IbcPacketReceiver} from "../interfaces/IbcReceiver.sol";
 import {L1Header, OpL2StateProof, Ics23Proof} from "../interfaces/IProofVerifier.sol";
 import {ILightClient} from "../interfaces/ILightClient.sol";
 import {IDispatcher} from "../interfaces/IDispatcher.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, IBCErrors, Ibc} from "../libs/Ibc.sol";
+import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, Ibc} from "../libs/Ibc.sol";
+import {IBCErrors} from "../libs/IbcErrors.sol";
 import {IbcUtils} from "../libs/IbcUtils.sol";
 
 /**

--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -476,6 +476,9 @@ contract Dispatcher is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuard, IDi
         if (_portChannelMap[msg.sender][channelId].counterpartyChannelId == bytes32(0)) {
             revert IBCErrors.channelNotOwnedBySender();
         }
+        if (timeoutTimestamp <= block.timestamp) {
+            revert IBCErrors.invalidPacket();
+        }
 
         _sendPacket(msg.sender, channelId, packet, timeoutTimestamp);
     }

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -32,8 +32,6 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
  * @dev This contract can integrate directly with dapps, or a middleware stack for packet routing.
  */
 contract UniversalChannelHandler is IbcReceiverBaseUpgradeable, UUPSUpgradeable, IbcUniversalChannelMW {
-    uint256[49] private __gap;
-
     bytes32 private _UNUSED; // Storage placeholder to ensure upgrade from this version is backwards compatible
 
     string public constant VERSION = "1.0";

--- a/contracts/core/UniversalChannelHandler.sol
+++ b/contracts/core/UniversalChannelHandler.sol
@@ -17,18 +17,10 @@
 
 pragma solidity 0.8.15;
 
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
-import {
-    IbcMiddleware,
-    IbcUniversalChannelMW,
-    IbcUniversalPacketReceiver,
-    IbcMwPacketReceiver,
-    IbcMwEventsEmitter
-} from "../interfaces/IbcMiddleware.sol";
-import {IbcReceiver} from "../interfaces/IbcReceiver.sol";
+import {IbcUniversalChannelMW, IbcUniversalPacketReceiver} from "../interfaces/IbcMiddleware.sol";
 import {IbcReceiverBaseUpgradeable} from "../interfaces/IbcReceiverUpgradeable.sol";
-import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket, UniversalPacket} from "../libs/Ibc.sol";
+import {ChannelOrder, IbcPacket, AckPacket, UniversalPacket} from "../libs/Ibc.sol";
 import {IbcUtils} from "../libs/IbcUtils.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 

--- a/contracts/examples/Mars.sol
+++ b/contracts/examples/Mars.sol
@@ -17,7 +17,7 @@
 
 pragma solidity ^0.8.9;
 
-import {IBCErrors, AckPacket, ChannelOrder, ChannelEnd} from "../libs/Ibc.sol";
+import {AckPacket, ChannelOrder} from "../libs/Ibc.sol";
 import {IbcReceiverBase, IbcReceiver, IbcPacket} from "../interfaces/IbcReceiver.sol";
 import {IbcDispatcher} from "../interfaces/IbcDispatcher.sol";
 

--- a/contracts/interfaces/IDispatcher.sol
+++ b/contracts/interfaces/IDispatcher.sol
@@ -19,9 +19,7 @@ pragma solidity ^0.8.0;
 import {IbcDispatcher, IbcEventsEmitter} from "./IbcDispatcher.sol";
 
 import {L1Header, OpL2StateProof, Ics23Proof} from "./IProofVerifier.sol";
-import {IbcChannelReceiver, IbcPacketReceiver} from "./IbcReceiver.sol";
-import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, IBCErrors, Ibc} from "../libs/Ibc.sol";
-import {IbcUtils} from "../libs/IbcUtils.sol";
+import {Channel, ChannelEnd, ChannelOrder, IbcPacket} from "../libs/Ibc.sol";
 import {ILightClient} from "./ILightClient.sol";
 
 interface IDispatcher is IbcDispatcher, IbcEventsEmitter {

--- a/contracts/interfaces/IUniversalChannelHandler.sol
+++ b/contracts/interfaces/IUniversalChannelHandler.sol
@@ -16,12 +16,10 @@
  */
 pragma solidity ^0.8.0;
 
-import {IbcDispatcher, IbcEventsEmitter} from "./IbcDispatcher.sol";
+import {IbcDispatcher} from "./IbcDispatcher.sol";
 
-import {L1Header, OpL2StateProof, Ics23Proof} from "./IProofVerifier.sol";
 import {IbcUniversalChannelMW} from "./IbcMiddleware.sol";
-import {Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, IBCErrors, Ibc} from "../libs/Ibc.sol";
-import {IbcUtils} from "../libs/IbcUtils.sol";
+import {ChannelOrder} from "../libs/Ibc.sol";
 
 interface IUniversalChannelHandler is IbcUniversalChannelMW {
     function registerMwStack(uint256 mwBitmap, address[] calldata mwAddrs) external;

--- a/contracts/interfaces/IbcDispatcher.sol
+++ b/contracts/interfaces/IbcDispatcher.sol
@@ -17,8 +17,7 @@
 
 pragma solidity ^0.8.9;
 
-import {Height, ChannelEnd, ChannelOrder, AckPacket} from "../libs/Ibc.sol";
-import {IbcChannelReceiver} from "./IbcReceiver.sol";
+import {Height, ChannelOrder, AckPacket} from "../libs/Ibc.sol";
 import {Ics23Proof} from "./IProofVerifier.sol";
 
 /**

--- a/contracts/interfaces/IbcReceiver.sol
+++ b/contracts/interfaces/IbcReceiver.sol
@@ -19,7 +19,7 @@ pragma solidity ^0.8.9;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IbcDispatcher} from "./IbcDispatcher.sol";
-import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket} from "../libs/Ibc.sol";
+import {ChannelOrder, IbcPacket, AckPacket} from "../libs/Ibc.sol";
 
 /**
  * @title IbcChannelReceiver

--- a/contracts/interfaces/IbcReceiverUpgradeable.sol
+++ b/contracts/interfaces/IbcReceiverUpgradeable.sol
@@ -56,4 +56,12 @@ contract IbcReceiverBaseUpgradeable is OwnableUpgradeable {
         __Ownable_init();
         dispatcher = _dispatcher;
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    // solhint-disable-next-line ordering
+    uint256[49] private __gap;
 }

--- a/contracts/interfaces/IbcReceiverUpgradeable.sol
+++ b/contracts/interfaces/IbcReceiverUpgradeable.sol
@@ -19,7 +19,6 @@ pragma solidity ^0.8.9;
 
 import {OwnableUpgradeable} from "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import {IbcDispatcher} from "./IbcDispatcher.sol";
-import {ChannelOrder, ChannelEnd, IbcPacket, AckPacket} from "../libs/Ibc.sol";
 
 contract IbcReceiverBaseUpgradeable is OwnableUpgradeable {
     IbcDispatcher public dispatcher;

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -36,7 +36,7 @@ struct IbcPacket {
     /// The sequence number of the packet on the given channel
     uint64 sequence;
     bytes data;
-    /// block height after which the packet times out
+    /// block height after which the packet times out; on the receiving chain ONLY
     Height timeoutHeight;
     /// block timestamp (in seconds after the unix epoch) after which the packet times out
     uint64 timeoutTimestamp;

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -17,10 +17,8 @@
 
 pragma solidity ^0.8.9;
 
-import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ProtoChannel, ProtoCounterparty} from "proto/channel.sol";
 import {Base64} from "base64/base64.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IBCErrors} from "./IbcErrors.sol";
 
 /**

--- a/contracts/libs/Ibc.sol
+++ b/contracts/libs/Ibc.sol
@@ -19,7 +19,6 @@ pragma solidity ^0.8.9;
 
 import {ProtoChannel, ProtoCounterparty} from "proto/channel.sol";
 import {Base64} from "base64/base64.sol";
-import {IBCErrors} from "./IbcErrors.sol";
 
 /**
  * Ibc.sol
@@ -149,38 +148,6 @@ struct Proof {
 }
 
 library Ibc {
-    /**
-     * Convert a non-0x-prefixed hex string to an address
-     * @param hexStr hex string to convert to address. Note that the hex string must not include a 0x prefix.
-     * hexStr is case-insensitive.
-     */
-    function _hexStrToAddress(string memory hexStr) external pure returns (address addr) {
-        if (bytes(hexStr).length != 40) {
-            revert IBCErrors.invalidHexStringLength();
-        }
-
-        bytes memory strBytes = bytes(hexStr);
-        bytes memory addrBytes = new bytes(20);
-
-        for (uint256 i = 0; i < 20; i++) {
-            uint8 high = uint8(strBytes[i * 2]);
-            uint8 low = uint8(strBytes[1 + i * 2]);
-            // Convert to lowercase if the character is in uppercase
-            if (high >= 65 && high <= 90) {
-                high += 32;
-            }
-            if (low >= 65 && low <= 90) {
-                low += 32;
-            }
-            uint8 digit = (high - (high >= 97 ? 87 : 48)) * 16 + (low - (low >= 97 ? 87 : 48));
-            addrBytes[i] = bytes1(digit);
-        }
-
-        assembly {
-            addr := mload(add(addrBytes, 20))
-        }
-    }
-
     // https://github.com/open-ibc/ibcx-go/blob/ef80dd6784fd/modules/core/24-host/keys.go#L135
     function channelProofKey(string calldata portId, bytes32 channelId) external pure returns (bytes memory proofKey) {
         proofKey = abi.encodePacked("channelEnds/ports/", portId, "/channels/", toStr(channelId));

--- a/contracts/libs/IbcErrors.sol
+++ b/contracts/libs/IbcErrors.sol
@@ -29,6 +29,7 @@ library IBCErrors {
     error invalidConnectionHops();
     error notEnoughGas();
     error invalidCharacter();
+    error invalidPacket();
 
     // packet sequence related errors.
     error invalidPacketSequence();

--- a/contracts/libs/IbcUtils.sol
+++ b/contracts/libs/IbcUtils.sol
@@ -50,7 +50,7 @@ library IbcUtils {
      * @param hexStr hex string to convert to address. Note that the hex string must not include a 0x prefix.
      * hexStr is case-insensitive.
      */
-    function hexStrToAddress(string memory hexStr) public pure returns (address addr) {
+    function hexStrToAddress(string memory hexStr) external pure returns (address addr) {
         bytes memory hexBytes = bytes(hexStr);
         if (bytes(hexStr).length != 40) {
             revert IBCErrors.invalidHexStringLength(); // Addresses must always be 20 bytes long; equal to 40 nibbles

--- a/contracts/libs/IbcUtils.sol
+++ b/contracts/libs/IbcUtils.sol
@@ -19,6 +19,7 @@ pragma solidity 0.8.15;
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {UniversalPacket} from "./Ibc.sol";
 import {IBCErrors} from "./IbcErrors.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 // define a library of Ibc utility functions
 library IbcUtils {
@@ -56,41 +57,41 @@ library IbcUtils {
             revert IBCErrors.invalidHexStringLength(); // Addresses must always be 20 bytes long; equal to 40 nibbles
         }
 
-        uint256 total = 0;
+        uint160 total = 0;
         uint256 base = 1;
         uint256 i = 40;
         while (i > 0) {
             i--;
-            uint256 digit;
+            uint160 digit;
             // Convert ASCII to integer value
             if (uint8(hexBytes[i]) >= 48 && uint8(hexBytes[i]) <= 57) {
                 /**
                  * This triggers if hexBytes[i] is equal to '0' to '9'
                  * '0' - '9' are 48-57 in ascii, and we want to map this into 0-9, so we subtract 48
                  */
-                digit = uint160(uint8(hexBytes[i]) - 48);
+                digit = uint8(hexBytes[i]) - 48;
             } else if (uint8(hexBytes[i]) >= 65 && uint8(hexBytes[i]) <= 70) {
                 /**
                  * This triggers if hexBytes[i] is equal to 'A' to 'F'
                  * 'A' - 'F' are 65-70 in ascii, and we want to map this into 0xa-0xf (equal to 10-15), so we
                  * sutract 55
                  */
-                digit = uint160(uint8(hexBytes[i]) - 55);
+                digit = uint8(hexBytes[i]) - 55;
             } else if (uint8(hexBytes[i]) >= 97 && uint8(hexBytes[i]) <= 102) {
                 /**
                  * This triggers if hexBytes[i] is equal to 'a' to 'f'
                  * 'a' to 'f' are 97-102 in ascii, and we want to amp this into 0xa-0xf (equal to 10-15), so we
                  * sutract 87
                  */
-                digit = uint160(uint8(hexBytes[i]) - 87);
+                digit = uint8(hexBytes[i]) - 87;
             } else {
                 revert IBCErrors.invalidCharacter();
             }
-            total += digit * base;
+            total += digit * SafeCast.toUint160(base);
             base *= 16;
         }
 
-        addr = address(uint160(total));
+        addr = address(total);
     }
 
     function toUniversalPacketBytes(UniversalPacket memory data) internal pure returns (bytes memory packetBytes) {
@@ -114,7 +115,7 @@ library IbcUtils {
 
     // toAddress converts a bytes32 to an address
     function toAddress(bytes32 b) internal pure returns (address out) {
-        out = address(uint160(uint256(b)));
+        out = address(SafeCast.toUint160(uint256(b)));
     }
 
     // toBytes32 converts an address to a bytes32

--- a/contracts/libs/IbcUtils.sol
+++ b/contracts/libs/IbcUtils.sol
@@ -16,7 +16,9 @@
  */
 pragma solidity 0.8.15;
 
-import {UniversalPacket, ChannelEnd, Strings, IBCErrors} from "./Ibc.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {UniversalPacket} from "./Ibc.sol";
+import {IBCErrors} from "./IbcErrors.sol";
 
 // define a library of Ibc utility functions
 library IbcUtils {

--- a/test/Dispatcher.gasGriefing.t.sol
+++ b/test/Dispatcher.gasGriefing.t.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.13;
 
 import {Base} from "./utils/Dispatcher.base.t.sol";
 import {GasUsingMars} from "./mocks/GasUsingMars.sol";
-import {IbcEndpoint, ChannelEnd, IbcPacket, IBCErrors} from "../contracts/libs/Ibc.sol";
+import {IbcEndpoint, ChannelEnd, IbcPacket} from "../contracts/libs/Ibc.sol";
+import {IBCErrors} from "../contracts/libs/IbcErrors.sol";
 import {IbcUtils} from "../contracts/libs/IbcUtils.sol";
 
 import {TestUtilsTest} from "./utils/TestUtils.t.sol";

--- a/test/Dispatcher/Dispatcher.ack.sol
+++ b/test/Dispatcher/Dispatcher.ack.sol
@@ -5,7 +5,8 @@ import "../utils/Dispatcher.base.t.sol";
 import "../../contracts/examples/Mars.sol";
 import "../../contracts/examples/Earth.sol";
 import "../../contracts/libs/Ibc.sol";
-import "../../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../../contracts/libs/IbcErrors.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
 import {PacketSenderTestBase} from "./Dispatcher.t.sol";
 

--- a/test/Dispatcher/Dispatcher.ack.sol
+++ b/test/Dispatcher/Dispatcher.ack.sol
@@ -81,6 +81,4 @@ contract DispatcherAckPacketTestSuite is PacketSenderTestBase {
 
         dispatcherProxy.acknowledgement(packet, ackPacket, validProof);
     }
-
-
 }

--- a/test/Dispatcher/Dispatcher.ack.sol
+++ b/test/Dispatcher/Dispatcher.ack.sol
@@ -81,4 +81,6 @@ contract DispatcherAckPacketTestSuite is PacketSenderTestBase {
 
         dispatcherProxy.acknowledgement(packet, ackPacket, validProof);
     }
+
+
 }

--- a/test/Dispatcher/Dispatcher.closeChannel.t.sol
+++ b/test/Dispatcher/Dispatcher.closeChannel.t.sol
@@ -7,15 +7,9 @@ import {RevertingStringCloseChannelMars, Mars} from "../../contracts/examples/Ma
 import {DummyLightClient} from "../../contracts/utils/DummyLightClient.sol";
 import "../utils/Dispatcher.base.t.sol";
 import {
-    Channel,
-    ChannelEnd,
-    ChannelOrder,
-    IbcPacket,
-    ChannelState,
-    AckPacket,
-    IBCErrors,
-    Ibc
+    Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, Ibc
 } from "../../contracts/libs/Ibc.sol";
+import {IBCErrors} from "../../contracts/libs/IbcErrors.sol";
 import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
 
 contract DispatcherCloseChannelTest is PacketSenderTestBase {

--- a/test/Dispatcher/Dispatcher.dappHandlerRevert.t.sol
+++ b/test/Dispatcher/Dispatcher.dappHandlerRevert.t.sol
@@ -5,7 +5,7 @@ import "../utils/Dispatcher.base.t.sol";
 import "../../contracts/examples/Mars.sol";
 import "../../contracts/examples/Earth.sol";
 import "../../contracts/libs/Ibc.sol";
-import "../../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
 
 contract DappHandlerRevertTests is Base {

--- a/test/Dispatcher/Dispatcher.multiclient.sol
+++ b/test/Dispatcher/Dispatcher.multiclient.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.15;
 
 import "../../contracts/libs/Ibc.sol";
 import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../../contracts/libs/IbcErrors.sol";
 import {Mars} from "../../contracts/examples/Mars.sol";
 import {Base} from "../utils/Dispatcher.base.t.sol";
 import {DummyLightClient} from "../../contracts/utils/DummyLightClient.sol";

--- a/test/Dispatcher/Dispatcher.proof.t.sol
+++ b/test/Dispatcher/Dispatcher.proof.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.15;
 
 import "../../contracts/libs/Ibc.sol";
-import "../../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
 import {Base} from "../utils/Dispatcher.base.t.sol";
 import {Dispatcher} from "../../contracts/core/Dispatcher.sol";
 import {IDispatcher} from "../../contracts/interfaces/IDispatcher.sol";

--- a/test/Dispatcher/Dispatcher.t.sol
+++ b/test/Dispatcher/Dispatcher.t.sol
@@ -273,10 +273,11 @@ contract PacketSenderTestBase is ChannelOpenTestBaseSetup {
     IbcPacket sentPacket;
     // ackPacket is the acknowledgement packet that is expected to be written for the `sentPacket`
     bytes ackPacket;
+    string marsPort;
 
     function setUp() public virtual override {
         super.setUp();
-        string memory marsPort = string(abi.encodePacked(portPrefix, getHexBytes(address(mars))));
+        marsPort = string(abi.encodePacked(portPrefix, getHexBytes(address(mars))));
         string memory revertingMarsPort = string(abi.encodePacked(portPrefix, getHexBytes(address(revertingBytesMars))));
 
         src = IbcEndpoint(marsPort, channelId);

--- a/test/Dispatcher/Dispatcher.t.sol
+++ b/test/Dispatcher/Dispatcher.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import "../../contracts/libs/Ibc.sol";
-import "../../contracts/libs/IbcUtils.sol";
+import {Ibc, ChannelEnd, IbcEndpoint, Height} from "../../contracts/libs/Ibc.sol";
+import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../../contracts/libs/IbcErrors.sol";
 import {Dispatcher} from "../../contracts/core/Dispatcher.sol";
 import {IbcEventsEmitter} from "../../contracts/interfaces/IbcDispatcher.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";

--- a/test/Dispatcher/Dispatcher.timeout.t.sol
+++ b/test/Dispatcher/Dispatcher.timeout.t.sol
@@ -6,6 +6,8 @@ import "../../contracts/examples/Mars.sol";
 import "../../contracts/examples/Earth.sol";
 import "../../contracts/libs/Ibc.sol";
 import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../../contracts/libs/IbcErrors.sol";
+
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
 import {PacketSenderTestBase} from "./Dispatcher.t.sol";
 

--- a/test/Dispatcher/Dispatcher.timeout.t.sol
+++ b/test/Dispatcher/Dispatcher.timeout.t.sol
@@ -93,4 +93,10 @@ contract DispatcherTimeoutPacketTestSuite is PacketSenderTestBase {
         vm.expectRevert(DummyLightClient.InvalidDummyNonMembershipProof.selector);
         dispatcherProxy.timeout(sentPacket, invalidProof);
     }
+
+    function test_invalidSendPacket() public {
+        sentPacket = genPacket(nextSendSeq);
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidPacket.selector));
+        mars.greet(payloadStr, channelId, uint64(block.timestamp) - 1);
+    }
 }

--- a/test/Dispatcher/Dispatcher.timeout.t.sol
+++ b/test/Dispatcher/Dispatcher.timeout.t.sol
@@ -5,7 +5,7 @@ import "../utils/Dispatcher.base.t.sol";
 import "../../contracts/examples/Mars.sol";
 import "../../contracts/examples/Earth.sol";
 import "../../contracts/libs/Ibc.sol";
-import "../../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../../contracts/libs/IbcUtils.sol";
 import {IbcReceiver} from "../../contracts/interfaces/IbcReceiver.sol";
 import {PacketSenderTestBase} from "./Dispatcher.t.sol";
 

--- a/test/Ibc.t.sol
+++ b/test/Ibc.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../contracts/libs/Ibc.sol";
-import "../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../contracts/libs/IbcUtils.sol";
 import "forge-std/Test.sol";
 import {IbcChannelReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 

--- a/test/Ibc.t.sol
+++ b/test/Ibc.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../contracts/libs/Ibc.sol";
 import {IbcUtils} from "../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../contracts/libs/IbcErrors.sol";
 import "forge-std/Test.sol";
 import {IbcChannelReceiver} from "../contracts/interfaces/IbcReceiver.sol";
 
@@ -104,6 +105,11 @@ contract IbcTest is Test {
         string memory invalidHexStr3 = "2G5AD5c4795c026514f8317c7a215E218DcCD6cF"; // Can't have G
         vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidCharacter.selector));
         IbcUtils.hexStrToAddress(invalidHexStr3);
+
+        string memory invalidHexStr4 = "hellohellohellohellohellohellohellohello"; // Can't convert arbitrary utf-8
+            // strings to addresses
+        vm.expectRevert(abi.encodeWithSelector(IBCErrors.invalidCharacter.selector));
+        IbcUtils.hexStrToAddress(invalidHexStr4);
     }
 
     function test_To_From_addr_hexStr(address addr) public {

--- a/test/Verifier.t.sol
+++ b/test/Verifier.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../contracts/core/OptimisticProofVerifier.sol";
 import "../contracts/libs/Ibc.sol";
-import "../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../contracts/libs/IbcUtils.sol";
 import "forge-std/Test.sol";
 import "./utils/Proof.base.t.sol";
 

--- a/test/universal.channel.t.sol
+++ b/test/universal.channel.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../contracts/libs/Ibc.sol";
-import "../contracts/libs/IbcUtils.sol";
+import {IbcUtils} from "../contracts/libs/IbcUtils.sol";
 import {Dispatcher} from "../contracts/core/Dispatcher.sol";
 import {IbcEventsEmitter} from "../contracts/interfaces/IbcDispatcher.sol";
 import {IbcReceiver} from "../contracts/interfaces/IbcReceiver.sol";

--- a/test/upgradeableProxy/DispatcherRC4.upgrade.t.sol
+++ b/test/upgradeableProxy/DispatcherRC4.upgrade.t.sol
@@ -234,6 +234,7 @@ contract DispatcherRC4MidwayUpgradeTest is ChannelHandShakeUpgradeUtil, UpgradeT
         upgradeDispatcher(portPrefix, address(dispatcherProxy));
         upgradeUch(address(uch));
         dispatcherProxy.setClientForConnection(connectionHops1[0], dummyLightClient2);
+        earth.authorizeChannel(_localUch.channelId);
 
         // Now recv and ack packet
         IbcEndpoint memory src = IbcEndpoint(sendingPortId, _local.channelId);

--- a/test/upgradeableProxy/upgrades/DispatcherV2.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2.sol
@@ -26,16 +26,10 @@ import {ILightClient} from "../../../contracts/interfaces/ILightClient.sol";
 import {IDispatcher} from "../../../contracts/interfaces/IDispatcher.sol";
 import {Dispatcher} from "../../../contracts/core/Dispatcher.sol";
 import {
-    Channel,
-    ChannelEnd,
-    ChannelOrder,
-    IbcPacket,
-    ChannelState,
-    AckPacket,
-    IBCErrors,
-    Ibc
+    Channel, ChannelEnd, ChannelOrder, IbcPacket, ChannelState, AckPacket, Ibc
 } from "../../../contracts/libs/Ibc.sol";
 import {IbcUtils} from "../../../contracts/libs/IbcUtils.sol";
+import {IBCErrors} from "../../../contracts/libs/IbcErrors.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 /**

--- a/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
+++ b/test/upgradeableProxy/upgrades/DispatcherV2Initializable.sol
@@ -19,7 +19,8 @@ pragma solidity ^0.8.9;
 
 import {DispatcherV2} from "./DispatcherV2.sol";
 import {ILightClient} from "../../../contracts/interfaces/ILightClient.sol";
-import {IBCErrors} from "../../../contracts/libs/Ibc.sol";
+import {IBCErrors} from "../../../contracts/libs/IbcErrors.sol";
+
 /**
  * @title Dispatcher
  * @author Polymer Labs
@@ -27,7 +28,6 @@ import {IBCErrors} from "../../../contracts/libs/Ibc.sol";
  *     Contract callers call this contract to send IBC-like msg,
  *     which can be relayed to a rollup module on the Polymerase chain
  */
-
 contract DispatcherV2Initializable is DispatcherV2 {
     function initialize(string memory initPortPrefix) public override reinitializer(2) {
         __Ownable_init();


### PR DESCRIPTION
PR to fix most issues identified in Bailsec's most recent audit! 

Specifically, this PR is to fix:

- 20: Unused imports
- 04: Function selector mismatch of onChanOpenConfirm
- 09: timeoutTimestamp can be in the past
- 28: IbcReceiverUpgradeable is not compatible with proxies
- 30:The _hexStrToAddress function doesn’t check if the string is a valid hex string
- 32: Unsafe downcasting could lead to unexpected behaviour
- 12: sendPacket lacks nonReentrant modifier
- 03: Blunder within writeTimeoutPacked function allows for marking received packet as timed out
- 21: Comment indicates version setting during _connectChannel is incorrect

And to clarify in comments (but not fix):
-  10: Unequal block.numbers amongst chains may result in unexpected timeout
- 25: Any counterparty can open a channel with UniversalChannelHandler
- 06: Blunder in channel closure mechanism can result in unidirectional counter channel still staying open


each commit message in this PR contains the issue number which it addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added channel authorization functionality in `DispatcherRC4MidwayUpgradeTest`.

- **Bug Fixes**
  - Improved packet handling and validation in `Dispatcher.sol`.
  - Enhanced error handling by adding new error definitions in `IBCErrors.sol`.

- **Refactor**
  - Simplified and optimized import statements across multiple contracts.
  - Restructured inheritance and authorization logic in `Earth.sol`.

- **Tests**
  - Added new test functions for packet validation and timeout scenarios.
  - Updated test files to reflect new import structures and added error handling checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->