### PR TITLE
fix contract spec to work with fee vault dispatcher

### DIFF
--- a/specs/contracts.spec.yaml
+++ b/specs/contracts.spec.yaml
@@ -42,6 +42,11 @@
       address: '{{IbcUtils}}'
   deployer: 'KEY_POLYMER'
 
+- name: FeeVault
+  description: 'FeeVault'
+  factoryName: 'FeeVault'
+  deployer: 'KEY_POLYMER'
+
 - name: DispatcherProxy
   description: 'Dispatcher proxy contract'
   factoryName: 'ERC1967Proxy'
@@ -49,9 +54,10 @@
     - '{{Dispatcher}}'
     - '$INITARGS' 
   init:
-    signature: 'initialize(string)'
+    signature: 'initialize(string,address)'
     args:
       - 'polyibc.{{chain.chainName}}.'
+      - '{{FeeVault}}'
   deployer: 'KEY_POLYMER'
 
 - name: UC


### PR DESCRIPTION
This is a quick PR to fix the default spec exported in the npm package, so that it correctly initializes dispatcher proxy with the new implementation (which takes in an additional feeVaultAddress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `DispatcherProxy` contract to include an additional argument for initialization, allowing users to specify an address for `FeeVault`. This enhances the contract's flexibility during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->