### PR TITLE
support deploying non vibc-core-sc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "main": "dist/index.js",
   "bin": {
     "deploy-vibc-core-smart-contracts": "./dist/scripts/deploy-script.js",


### PR DESCRIPTION
## why this change is needed

we'd like to re-use the deployment tool in this repo for non vibc core sc deployments. it is not supported for the reason below:

the public deployment function `deployToChain` assumes for each contract it deploys, there is a corresponding factory type in `./src/evm/contracts`, however this is not the case for smart contracts defined outside this repo.

## implementation

to address this issue, we modify the API to allow caller to optionally provide an object with extra factory objects. since the new parameter has a default value, it doesn't break existing usage. 

example usage:

```
import * as griContracts from 'generalisedincentives'
...
    const deployed = await Promise.all(
      chains.toList().map((chain) => {
        return deployToChain(
          chain,
          this.getAccountRegistry(chain.chainName),
          spec.subset(),
          this.logger,
          !!options?.dryRun,
          true,
          false,
          griContracts,
        ).then(async (result) => {
          await sendTxToChain(
            chain,
            this.getAccountRegistry(chain.chainName),
            result.contracts,
            this.contractsSetupSpec,
            this.logger,
            false
          )
          return result
        })
      })
    )
```

## test

tested with e2e tests with sim client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the application version from 2.1.7 to 2.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->