### PR TITLE
update fork testing to use contract setup & add incrementing local no…

### DIFF
--- a/src/scripts/update-contracts-script.ts
+++ b/src/scripts/update-contracts-script.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { ContractRegistryLoader, parseObjFromFile } from "..";
 import { loadContractUpdateRegistry } from "../evm/schemas/contractUpdate";
-import { updateContractForChain } from "../updateContract";
+import { updateContractsForChain } from "../updateContract";
 
 import { getOutputLogger } from "../utils/cli";
 import { UPDATE_SPECS_PATH } from "../utils/constants";
@@ -15,7 +15,7 @@ async function main() {
     parseObjFromFile(updateSpecs)
   );
 
-  updateContractForChain(
+  updateContractsForChain(
     chain,
     accounts.mustGet(chain.chainName),
     ContractRegistryLoader.emptySingle(),

--- a/src/updateContract.ts
+++ b/src/updateContract.ts
@@ -12,7 +12,7 @@ import { readDeploymentFilesIntoEnv } from "./utils/io";
 import { TxItemSchema } from "./evm/schemas/tx";
 
 // Combination of sendTxToChain and deployContracts. Can do both from a single deploy file, and uses zod to parse the schema.
-export async function updateContractForChain(
+export async function updateContractsForChain(
   chain: Chain,
   accountRegistry: AccountRegistry,
   existingContracts: ContractRegistry,
@@ -82,6 +82,7 @@ export async function updateContractForChain(
         parsedTxItem.data,
         logger,
         dryRun,
+        nonces,
         env
       );
       continue;


### PR DESCRIPTION
PR to add the following fixes/updates to our deployment spec:
- Update fork test to use update spec instead of contract & tx specs. This pivots to using our new functionality while still allowing us to have support for our e2e for our old functionality
- add local nonce incrementing to our tx sending. This is aready done in our contract deployments to avoid nonce too low errors. Now this PR adds it for our transactions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new asynchronous function for organized nonce management during sender transactions.
  - Added a mechanism for handling contract upgrades instead of new deployments in the deployment script.
  
- **Bug Fixes**
  - Enhanced transaction sending capabilities by integrating nonce management.

- **Refactor**
  - Updated function names to improve clarity and indicate potential for handling multiple contracts.

- **Chores**
  - Improved structure and organization of contract update and transaction management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->