### PR TITLE
remove unused dummylight client from fork test + clean up update cont…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "bin": {
     "verify-vibc-core-smart-contracts": "./dist/scripts/verify-contract-script.js",

--- a/specs/update.spec.yaml
+++ b/specs/update.spec.yaml
@@ -138,15 +138,6 @@
   args:   
     - '{{Dispatcher}}'
 
-- name: DispatcherUpgrade 
-  description: 'UUPS Upgrade for dispatcher contract implementation' 
-  deployer: 'KEY_DEPLOYER' 
-  signature: "upgradeTo(address)" 
-  address: '{{DispatcherProxy}}' 
-  factoryName: "Dispatcher" 
-  args:   
-    - '{{Dispatcher}}'
-
 - name: UCH Upgrade 
   description: 'Upgrade for uch contract'
   deployer: 'KEY_DEPLOYER' 

--- a/test/Fork/Dispatcher.deploy.t.sol
+++ b/test/Fork/Dispatcher.deploy.t.sol
@@ -23,7 +23,6 @@ import {IbcReceiver, IbcChannelReceiver} from "../../contracts/interfaces/IbcRec
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {OptimisticLightClient} from "../../contracts/core/OptimisticLightClient.sol";
 import {IProofVerifier} from "../../contracts/core/OptimisticProofVerifier.sol";
-import {DummyLightClient} from "../../contracts/utils/DummyLightClient.sol";
 import {Dispatcher} from "../../contracts/core/Dispatcher.sol";
 
 import {IDispatcher} from "../../contracts/interfaces/IDispatcher.sol";
@@ -39,7 +38,6 @@ import "forge-std/Test.sol";
 struct ChainAddresses {
     IDispatcher dispatcherProxy;
     IUniversalChannelHandler uch;
-    ILightClient dummyLightClient;
     ILightClient optimisticLightClient;
     address owner; // Owner Address of dispatcher
 }
@@ -54,7 +52,6 @@ contract DispatcherDeployTest is ChannelHandShakeUpgradeUtil, UpgradeTestUtils {
         ChainAddresses memory addresses = ChainAddresses(
             IDispatcher(vm.envAddress("DispatcherProxy")),
             IUniversalChannelHandler(vm.envAddress("UCProxy")),
-            ILightClient(vm.envAddress("DummyLightClient")),
             ILightClient(vm.envAddress("OptimisticLightClient")),
             vm.envAddress("OwnerAddress")
         );


### PR DESCRIPTION
PR to clean up unused dummylight client from our fork deployment test. This will cause our mainnet deployment to fail until we fix this patch, since we won't have a dummylight client. 

Also, this PR does another minor patch of removing a copy of having multiple dispatcher proxy updates in the update spec file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Incremented version number from 3.0.0 to 3.0.1, indicating a patch release with minor improvements.
	- Removed the `DispatcherUpgrade` section, streamlining upgrade strategy and management.
- **Chores**
	- Updated import statements in the deployment script to enhance clarity by removing unused components and simplifying dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->