### PR TITLE
Raunak/zellic 08 2024 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "dist/index.js",
   "bin": {
     "verify-vibc-core-smart-contracts": "./dist/scripts/verify-contract-script.js",

--- a/specs/update.spec.yaml
+++ b/specs/update.spec.yaml
@@ -143,7 +143,7 @@
   deployer: 'KEY_DEPLOYER' 
   signature: "upgradeTo(address)"
   address: '{{ UCProxy }}' 
-  factoryName: "UC"
+  factoryName: "UniversalChannelHandler"
   args: 
     - '{{UC}}'
 

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -200,6 +200,11 @@ export async function readMetadata(factoryName: string) {
   return JSON.stringify(JSON.parse(data).metadata);
 }
 
+export async function readFactoryAbi(factoryName: string) {
+  const data = await readArtifactFile(factoryName);
+  return JSON.parse(data).abi;
+}
+
 // Given a chain object, return the folder in which deployments for this chain will be
 export const getDeployFolderForChain = (chain: ChainFolder) => {
   return path.join(

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -231,12 +231,12 @@ export async function writeDeployedContractToFile(
     libraries: deployedContract.libraries,
   });
 
-  fs.writeFile(fullPath, outData, (err) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-  });
+  try {
+    await fsAsync.writeFile(fullPath, outData);
+  } catch (e) {
+    console.error(e);
+    return;
+  }
 }
 
 // Read existing accounts into env

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -31,7 +31,10 @@ export class Registry<T, S = T> {
     const { nameFunc = (t: any) => t["name"], toObj = (t: any) => t } = options
       ? options
       : {};
-    this.registry = new Map(src.map((item) => [nameFunc(item), item]));
+    this.registry = new Map<string, T>();
+    src.forEach((item) => {
+      this.set(nameFunc(item), item);
+    });
     this.itemToObj = toObj;
     this.nameFunc = nameFunc;
     this.nameInParent = options?.nameInParent;


### PR DESCRIPTION
PR to fix the following to reduce the potential of a non-malicious mistake in our deploy scripts
 - add an await to the writeDeployedContractsToFile. This would prevent any race conditions where the abi updated after a send contract tx and a following update tx within the same spec. Also helps in the case of an error.
 - add validation in our Registry class for duplicate keys. this impacts our contractUpdateSpec, which inherits from this class. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Restructured account-related functionalities to a new schemas directory for improved organization.
	- Introduced a new function to read factory ABI, enhancing access to smart contract data.
	- Added public access to the `updateContractsForChain` function for managing contract states.

- **Improvements**
	- Enhanced error handling and readability in file writing operations by adopting a promise-based approach.
	- Improved clarity and maintainability in the Registry class by explicitly populating the registry.
	- Clarified address assignment logic in the AccountRegistry class to ensure accurate data processing.

- **Bug Fixes**
	- Updated module paths to ensure proper resolution of dependencies related to account functionalities.
	- Enhanced robustness in the `sendTx` method by introducing a fallback mechanism for ABI retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->