### PR TITLE
fix npm file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "main": "dist/index.js",
   "bin": {
     "verify-vibc-core-smart-contracts": "./dist/scripts/verify-contract-script.js",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,10 +9,13 @@ export const DEFAULT_CHAIN_ID = "31337";
 export const DEFAULT_CHAIN_NAME = "local";
 export const DEFAULT_VERIFIER = "blockscout";
 export const MODULE_ROOT_PATH =
-  process.env.MODULE_ROOT_PATH ||
-  path.resolve(__dirname, '../'); // Note: this is impacted by the tsup config since that can potential change where this file ends up being built to 
+  process.env.MODULE_ROOT_PATH || path.resolve(__dirname, "..", ".."); // Note: this is impacted by the tsup config since that can potential change where this file ends up being built to
+export const PARENT_MODULE_ROOT_PATH = path.dirname(path.resolve("package.json")); // Path of module using this package; path.resolve uses cwd so this should typically be the root of the module that's running the bin
 const DEFAULT_ARTIFACTS_PATH = path.resolve(MODULE_ROOT_PATH, "out");
-const DEFAULT_DEPLOYMENTS_PATH = path.resolve(MODULE_ROOT_PATH, "./deployments");
+const DEFAULT_DEPLOYMENTS_PATH = path.resolve(
+  PARENT_MODULE_ROOT_PATH,
+  "deployments"
+);
 const DEFAULT_SPECS_PATH = path.resolve(MODULE_ROOT_PATH, "./specs");
 const DEFAULT_DEPLOYMENT_ENVIRONMENT = "local"; // Deployment Environment disambiguates between deployment environments on the same chains (e.g. staging testnet vs prod testnet) This should be one of the following: local, staging, prod, mainnet
 
@@ -37,14 +40,6 @@ const SPECS_BASE_PATH = process.env.SPECS_BASE_PATH
   ? process.env.SPECS_BASE_PATH
   : DEFAULT_SPECS_PATH;
 
-export const DEPLOY_SPECS_PATH = process.env.DEPLOY_SPECS_PATH
-  ? process.env.DEPLOY_SPECS_PATH
-  : path.resolve(SPECS_BASE_PATH, "contracts.spec.yaml");
-
-export const UPGRADE_SPECS_PATH = process.env.UPGRADE_SPECS_PATH
-  ? process.env.UPGRADE_SPECS_PATH
-  : path.resolve(SPECS_BASE_PATH, "upgrade.spec.yaml");
-
 export const UPDATE_SPECS_PATH = process.env.UPDATE_SPECS_PATH
   ? process.env.UPDATE_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "update.spec.yaml");
@@ -52,8 +47,3 @@ export const UPDATE_SPECS_PATH = process.env.UPDATE_SPECS_PATH
 export const ACCOUNTS_SPECS_PATH = process.env.ACCOUNTS_SPECS_PATH
   ? process.env.ACCOUNTS_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "evm.accounts.yaml");
-
-export const DISPATCHER_SETUP_SPECS_PATH = process.env
-  .DISPATCHER_SETUP_SPECS_PATH
-  ? process.env.DISPATCHER_SETUP_SPECS_PATH
-  : path.resolve(SPECS_BASE_PATH, "contracts.setup.spec.yaml");

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -15,11 +15,9 @@ import {
   CHAIN_NAME,
   CHAIN_ID,
   RPC_URL,
-  DEPLOY_SPECS_PATH,
   PACKAGE_VERSION,
   DEPLOYMENT_ENVIRONMENT,
   ANVIL_PORT,
-  UPGRADE_SPECS_PATH,
   UPDATE_SPECS_PATH,
 } from "./constants";
 import yargs from "yargs/yargs";
@@ -365,9 +363,6 @@ export async function parseArgsFromCLI() {
   const accountSpecs =
     (argv1.ACCOUNT_SPECS_PATH as string) || ACCOUNTS_SPECS_PATH;
 
-  const deploySpecs = (argv1.DEPLOY_SPECS_PATH as string) || DEPLOY_SPECS_PATH;
-  const upgradeSpecs =
-    (argv1.UPGRADE_SPECS_PATH as string) || UPGRADE_SPECS_PATH;
   const updateSpecs = (argv1.UPDATE_SPECS_PATH as string) || UPDATE_SPECS_PATH;
   const anvilPort = (argv1.ANVIL_PORT as string) || ANVIL_PORT;
 
@@ -394,9 +389,7 @@ export async function parseArgsFromCLI() {
     chain: chainParse.data,
     accounts,
     accountSpecs,
-    upgradeSpecs,
     updateSpecs,
-    deploySpecs,
     args: argv1,
     anvilPort,
   };


### PR DESCRIPTION
PR to fix bugs in our file exporting which was causing bugs in infra. 

Seems like in general this is hard, since path exporting is impacted by our tsup config _and_ our package.json exports. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the package `@open-ibc/vibc-core-smart-contracts` to 3.0.6, indicating minor enhancements.
	- Introduced a new constant for improved path resolution.

- **Bug Fixes**
	- Simplified argument parsing by removing outdated specification paths.

- **Refactor**
	- Restructured path management for deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->