### PR TITLE
fix low-level connectiontolightclientmapping calculation in unit tests

### DIFF
--- a/test/Dispatcher/Dispatcher.multiclient.sol
+++ b/test/Dispatcher/Dispatcher.multiclient.sol
@@ -142,6 +142,8 @@ contract DispatcherRealProofMultiClient is Base {
     }
 
     function test_Dispatcher_removeConnection() public {
+        // Make sure that the connection exists before we delete it
+        assertEq(_getConnectiontoClientIdMapping(connectionHops1[0]), address(opLightClient));
         Ics23Proof memory openChannelProof =
             load_proof("/test/payload/channel_confirm_pending_proof.hex", address(opLightClient));
 
@@ -153,7 +155,7 @@ contract DispatcherRealProofMultiClient is Base {
 
         // Remove connection to ensure packet can't be acked after removing light client
         dispatcherProxy.removeConnection(connectionHops1[0]);
-        assertEq(_getConnectiontoClientIdMapping(connectionHops1[0]), 0);
+        assertEq(_getConnectiontoClientIdMapping(connectionHops1[0]), address(0));
 
         vm.expectRevert(abi.encodeWithSelector(IBCErrors.lightClientNotFound.selector, connectionHops1[0]));
         dispatcherProxy.acknowledgement(packet, bytes("ack"), openChannelProof);

--- a/test/utils/Dispatcher.base.t.sol
+++ b/test/utils/Dispatcher.base.t.sol
@@ -53,7 +53,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
         uint256 fees
     );
 
-    uint32 CONNECTION_TO_CLIENT_ID_STARTING_SLOT = 259;
+    uint32 CONNECTION_TO_CLIENT_ID_STARTING_SLOT = 260;
     uint32 SEND_PACKET_COMMITMENT_STARTING_SLOT = 255;
     uint64 UINT64_MAX = 18_446_744_073_709_551_615;
     bytes32 PEPTIDE_CHAIN_ID = bytes32(uint256(444));
@@ -286,9 +286,10 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
     }
 
     // Store connection in channelid to connection mapping using store
-    function _getConnectiontoClientIdMapping(string memory connection) internal view returns (uint256 clientId) {
-        bytes32 clientIdSlot = keccak256(abi.encode(connection, CONNECTION_TO_CLIENT_ID_STARTING_SLOT));
-        clientId = uint256(vm.load(address(dispatcherProxy), clientIdSlot));
+    function _getConnectiontoClientIdMapping(string memory connection) internal view returns (address clientId) {
+        bytes32 clientIdSlot =
+            keccak256(abi.encodePacked(bytes(connection), uint256(CONNECTION_TO_CLIENT_ID_STARTING_SLOT)));
+        clientId = address(uint160(uint256(vm.load(address(dispatcherProxy), clientIdSlot))));
     }
 
     function load_proof(string memory filepath, address lightClient) internal returns (Ics23Proof memory) {


### PR DESCRIPTION
thanks to @nicopernas for finding out that the low-level caluclation was incorrect in our test suite. 

This pr fixes this, and also now actually tests that this calculation is working 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved connection removal logic to ensure proper verification before and after deletion.
  
- **New Features**
	- Updated connection-to-client ID mapping function to return an address instead of a numeric ID, enhancing clarity and functionality. 

- **Chores**
	- Adjusted constant value for better alignment with internal logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->