### PR TITLE
remove ack packet commitment mapping from dispatcher

### DIFF
--- a/contracts/core/Dispatcher.sol
+++ b/contracts/core/Dispatcher.sol
@@ -60,8 +60,6 @@ contract Dispatcher is Ownable2StepUpgradeable, UUPSUpgradeable, ReentrancyGuard
     mapping(address => mapping(bytes32 => mapping(uint64 => bool))) private _sendPacketCommitment;
     // keep track of received packets to prevent replay attack
     mapping(address => mapping(bytes32 => mapping(uint64 => bool))) private _recvPacketReceipt;
-    // keep track of outbound ack packets to prevent replay attack
-    mapping(address => mapping(bytes32 => mapping(uint64 => bool))) private _ackPacketCommitment;
 
     ILightClient _UNUSED; // From previous dispatcher version
     mapping(bytes32 => string) private _channelIdToConnection;
@@ -624,13 +622,6 @@ contract Dispatcher is Ownable2StepUpgradeable, UUPSUpgradeable, ReentrancyGuard
         } else {
             ack = AckPacket(false, data);
         }
-        bool hasAckPacketCommitment = _ackPacketCommitment[receiver][packet.dest.channelId][packet.sequence];
-        // check is not necessary for sync-acks
-        if (hasAckPacketCommitment) {
-            revert IBCErrors.ackPacketCommitmentAlreadyExists();
-        }
-
-        _ackPacketCommitment[receiver][packet.dest.channelId][packet.sequence] = true;
 
         emit WriteAckPacket(receiver, packet.dest.channelId, packet.sequence, ack);
     }

--- a/test/utils/Dispatcher.base.t.sol
+++ b/test/utils/Dispatcher.base.t.sol
@@ -55,6 +55,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
 
     uint32 CONNECTION_TO_CLIENT_ID_STARTING_SLOT = 259;
     uint32 SEND_PACKET_COMMITMENT_STARTING_SLOT = 255;
+    uint32 CHANNEL_ID_TO_CONNECTION_STARTING_SLOT = 258;
     uint64 UINT64_MAX = 18_446_744_073_709_551_615;
     bytes32 PEPTIDE_CHAIN_ID = bytes32(uint256(444));
 
@@ -269,7 +270,7 @@ contract Base is IbcEventsEmitter, ProofBase, TestUtilsTest {
 
     // Store connection in channelid to connection mapping using store
     function _storeChannelidToConnectionMapping(bytes32 channelId, bytes32 connection) internal {
-        bytes32 chanIdToConnectionMapping = keccak256(abi.encode(channelId, uint32(259)));
+        bytes32 chanIdToConnectionMapping = keccak256(abi.encode(channelId, CHANNEL_ID_TO_CONNECTION_STARTING_SLOT));
         vm.store(address(dispatcherProxy), chanIdToConnectionMapping, connection);
     }
 


### PR DESCRIPTION
Pr to remove the unused ackpacket commitment mapping from dispatcher. 

This mapping was originally included for async acks, but adds gas cost of an SLOAD, so we've decided to get rid of it for now 