### PR TITLE
remove bun lock checks in github workflows

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate Bindings
         run: |
-          bun install --frozen-lockfile
+          bun install
           bun run build
 
       - name: Check for Bindings Changes

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -26,7 +26,7 @@ jobs:
       
       - name: Generate Bindings
         run: |
-          bun install --frozen-lockfile
+          bun install
           bun run build
 
       - name: Check contract sizes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          bun install --frozen-lockfile
+          bun install
           bun run lint
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Update NPM Registry
         run: |
-          bun install --frozen-lockfile
+          bun install
           bun run build
           npm publish
         env:


### PR DESCRIPTION
this PR removes the frozen lock file check to allow merging dependabot prs more easily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workflows for dependency installation processes, enhancing flexibility during installation.
  
- **Bug Fixes**
	- Corrected indentation in the binding generation step for improved workflow clarity. 

- **Chores**
	- Adjusted installation commands across multiple workflows to streamline dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->