### PR TITLE
Raunak/account registry cleanup

### DIFF
--- a/src/evm/schemas/account.ts
+++ b/src/evm/schemas/account.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import { Registry } from "../../utils/registry";
 import { renderString } from "../../utils/io";
-import { initializedMultisig } from "./multisig";
+import { initializedMultisigConfig, uninitializedMultisigConfig } from "./multisig";
 import {
   isMnemonic,
   isPrivateKey,
@@ -24,7 +24,7 @@ const keyStore = z.object({
 export type KeyStore = z.infer<typeof keyStore>;
 
 export const evmAccounts = z.array(
-  z.union([singleSigAccount, initializedMultisig])
+  z.union([singleSigAccount, initializedMultisigConfig, uninitializedMultisigConfig])
 ); // Type of account that one can send transactions from
 export type EvmAccounts = z.infer<typeof evmAccounts>;
 export const EvmAccountsConfig = z.union([evmAccounts, keyStore]);
@@ -104,7 +104,7 @@ export class SingleSigAccountRegistry extends Registry<Wallet> {
 // load a Map of { [name: string]: Wallet } from EvmAccountsSchema object
 export function loadEvmAccounts(config: unknown): Registry<Wallet> {
   if (!isEvmAccountsConfig(config)) {
-    throw new Error(`Error parsing schema: ${config}`);
+    throw new Error(`Error parsing schema: ${config}: \n ${EvmAccountsConfig.safeParse(config).error}`);
   }
   const walletMap = new Registry<Wallet>([]);
 

--- a/src/evm/schemas/multisig.ts
+++ b/src/evm/schemas/multisig.ts
@@ -1,37 +1,52 @@
 import { z } from 'zod';
-import {singleSigAccount, wallet} from './wallet';
+import { wallet } from './wallet';
 
-// defined in an account spec, which will be cconvertedi nto an initialized multisig config once we deploy the multisig contract
-export const uninitializedMultisigConfig = z.object({
-  name: z.string().min(1),
-  chainId: z.number(),
-  owners: z.array(z.string().min(1)), 
-  signer: singleSigAccount 
-}) .strict()
+// defined in an account spec, which will be converted into an initialized multisig config once we deploy the multisig contract
+export const uninitializedMultisigConfig = z
+  .object({
+    name: z.string().min(1),
+    chainId: z.number(),
+    privateKey: z.string().min(1),
+    owners: z.array(z.string().min(1)),
+    threshold: z.number(),
+  })
+  .strict();
 
 // Defined in an account spec, which is not necessarily in a config
-export const initializedMultisigConfig = z.object({
-  name: z.string().min(1),
-  chainId: z.number(),
-  safeAddress: z.string().min(1),
-  signer: singleSigAccount 
-}) .strict()
-
+export const initializedMultisigConfig = z
+  .object({
+    name: z.string().min(1),
+    chainId: z.number(),
+    privateKey: z.string().min(1),
+    safeAddress: z.string().min(1),
+  })
+  .strict();
 
 // Multisig which is described in an account spec but is not yet initialized. (i.e. multisig contract has not been deployed yet)
-export const unInitializedMultisig = z.intersection(
-    uninitializedMultisigConfig,
-    z.object({wallet: wallet})
-)
+export const unInitializedMultisig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  privateKey: z.string().min(1),
+  owners: z.array(z.string().min(1)),
+  threshold: z.number(),
+  wallet: wallet,
+});
 
 // Multisig which has been deployed & can be used to propose transactions. This is the type that loadEvmAccounts will return for multisig types
-export const initializedMultisig = z.intersection(
-  initializedMultisigConfig,
-    z.object({wallet: wallet})
-);
+export const initializedMultisig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  privateKey: z.string().min(1),
+  safeAddress: z.string().min(1),
+  wallet: wallet,
+});
 
-export type UninitializedMultisigConfig = z.infer<typeof uninitializedMultisigConfig>;
-export type InitializedMultisigConfig = z.infer<typeof initializedMultisigConfig>;
+export type UninitializedMultisigConfig = z.infer<
+  typeof uninitializedMultisigConfig
+>;
+export type InitializedMultisigConfig = z.infer<
+  typeof initializedMultisigConfig
+>;
 export type UninitializedMultisig = z.infer<typeof unInitializedMultisig>;
 export type InitializedMultisig = z.infer<typeof initializedMultisig>;
 
@@ -41,7 +56,7 @@ export const isUninitializedMultisigConfig = (
 ): account is UninitializedMultisigConfig => {
   return uninitializedMultisigConfig.safeParse(account).success;
 };
-  
+
 export const isUninitializedMultisig = (
   account: unknown
 ): account is UninitializedMultisig => {
@@ -60,10 +75,17 @@ export const isInitializedMultisig = (
   return initializedMultisig.safeParse(account).success;
 };
 
-export const isMultisig = (account: unknown): account is InitializedMultisig | UninitializedMultisig => {
+export const isMultisig = (
+  account: unknown
+): account is InitializedMultisig | UninitializedMultisig => {
   return isInitializedMultisig(account) || isUninitializedMultisig(account);
 };
 
-export const isMultisigConfig = (account: unknown): account is InitializedMultisigConfig | UninitializedMultisigConfig => {
-  return isInitializedMultisigConfig(account) || isUninitializedMultisigConfig(account);
-}
+export const isMultisigConfig = (
+  account: unknown
+): account is InitializedMultisigConfig | UninitializedMultisigConfig => {
+  return (
+    isInitializedMultisigConfig(account) ||
+    isUninitializedMultisigConfig(account)
+  );
+};

--- a/src/evm/schemas/multisig.ts
+++ b/src/evm/schemas/multisig.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import {singleSigAccount, wallet} from './wallet';
+
+// defined in an account spec, which will be cconvertedi nto an initialized multisig config once we deploy the multisig contract
+export const uninitializedMultisigConfig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  owners: z.array(z.string().min(1)), 
+  signer: singleSigAccount 
+}) .strict()
+
+// Defined in an account spec, which is not necessarily in a config
+export const initializedMultisigConfig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  safeAddress: z.string().min(1),
+  signer: singleSigAccount 
+}) .strict()
+
+
+// Multisig which is described in an account spec but is not yet initialized. (i.e. multisig contract has not been deployed yet)
+export const unInitializedMultisig = z.intersection(
+    uninitializedMultisigConfig,
+    z.object({wallet: wallet})
+)
+
+// Multisig which has been deployed & can be used to propose transactions. This is the type that loadEvmAccounts will return for multisig types
+export const initializedMultisig = z.intersection(
+  initializedMultisigConfig,
+    z.object({wallet: wallet})
+);
+
+export type UninitializedMultisigConfig = z.infer<typeof uninitializedMultisigConfig>;
+export type InitializedMultisigConfig = z.infer<typeof initializedMultisigConfig>;
+export type UninitializedMultisig = z.infer<typeof unInitializedMultisig>;
+export type InitializedMultisig = z.infer<typeof initializedMultisig>;
+
+// Type Guards
+export const isUninitializedMultisigConfig = (
+  account: unknown
+): account is UninitializedMultisigConfig => {
+  return uninitializedMultisigConfig.safeParse(account).success;
+};
+  
+export const isUninitializedMultisig = (
+  account: unknown
+): account is UninitializedMultisig => {
+  return unInitializedMultisig.safeParse(account).success;
+};
+
+export const isInitializedMultisigConfig = (
+  account: unknown
+): account is InitializedMultisigConfig => {
+  return initializedMultisigConfig.safeParse(account).success;
+};
+
+export const isInitializedMultisig = (
+  account: unknown
+): account is InitializedMultisig => {
+  return initializedMultisig.safeParse(account).success;
+};
+
+export const isMultisig = (account: unknown): account is InitializedMultisig | UninitializedMultisig => {
+  return isInitializedMultisig(account) || isUninitializedMultisig(account);
+};
+
+export const isMultisigConfig = (account: unknown): account is InitializedMultisigConfig | UninitializedMultisigConfig => {
+  return isInitializedMultisigConfig(account) || isUninitializedMultisigConfig(account);
+}

--- a/src/evm/schemas/sendingAccount.ts
+++ b/src/evm/schemas/sendingAccount.ts
@@ -1,0 +1,144 @@
+import { fs } from "zx";
+import { Registry } from "../../utils/registry";
+import {
+  createWallet,
+  isEvmAccounts,
+  isEvmAccountsConfig,
+  isKeyStore,
+} from "./account";
+import { isPrivateKey, isSingleSigAccount, Wallet } from "./wallet";
+import {
+  InitializedMultisig,
+  isInitializedMultisig,
+  isMultisig,
+  isMultisigConfig,
+  isUninitializedMultisig,
+  UninitializedMultisig,
+} from "./multisig";
+import path from "path";
+import { ethers } from "ethers";
+
+export type SendingAccount =
+  | Wallet
+  | InitializedMultisig
+  | UninitializedMultisig;
+
+export class SendingAccountRegistry extends Registry<SendingAccount> {
+  static load(config: unknown[], name: string): SendingAccountRegistry {
+    return new SendingAccountRegistry(
+      loadSendingAccounts(config),
+      config,
+      name
+    );
+  }
+
+  static loadMultiple(registryItems: { name: string; registry: any }[]) {
+    const result = new Registry([] as SendingAccountRegistry[], {
+      toObj: (t) => {
+        return { name: t.name, registry: t.serialize() };
+      },
+    });
+    for (const item of registryItems) {
+      result.set(
+        item.name,
+        SendingAccountRegistry.load(item.registry, item.name)
+      );
+    }
+    return result;
+  }
+
+  constructor(
+    r: Registry<SendingAccount>,
+    private config: any[],
+    name: string
+  ) {
+    super([], { nameInParent: name });
+    for (const [name, wallet] of r.entries()) {
+      this.set(name, wallet);
+    }
+  }
+
+  // return the same config obj that was used to load the accounts, but filtered by current account names
+  public serialize() {
+    const wallets = this.toList();
+    return this.config.map((item, index) => {
+      const walletItem = wallets[index];
+      return {
+        name: item.name,
+        privateKey: this.getSinglePrivateKeyFromAccount(item.name),
+        address: isMultisig(walletItem)
+          ? walletItem.wallet.address
+          : walletItem.address,
+        ...item,
+      };
+    });
+  }
+
+  public getSinglePrivateKeyFromAccount = (accountName: string) => {
+    const account = this.mustGet(accountName);
+    if (isSingleSigAccount(account) && isPrivateKey(account)) {
+      return account.privateKey;
+    } else if (
+      isInitializedMultisig(account) ||
+      isUninitializedMultisig(account)
+    ) {
+      return account.wallet.privateKey;
+    }
+    throw new Error(
+      `Can't find private key for ${accountName} in this registry`
+    );
+  };
+  // Connect all accounts to the provider
+  public connectProviderAccounts = (rpc: string) => {
+    const provider = ethers.getDefaultProvider(rpc);
+    // const newAccounts = this.subset([]);
+    for (const [name, account] of this.entries()) {
+      if (isMultisig(account)) {
+        const newMultisigWallet = {
+          ...account,
+          wallet: account.wallet.connect(provider),
+        };
+        this.set(name, newMultisigWallet, true);
+      } else {
+        this.set(name, account.connect(provider), true);
+      }
+    }
+    return this;
+  };
+}
+
+// Load a map of evm accounts from a config through connecting wallets, can either take in sending accounts or not
+export function loadSendingAccounts(config: unknown): Registry<SendingAccount> {
+  if (!isEvmAccountsConfig(config)) {
+    throw new Error(`Error parsing schema: ${config}`);
+  }
+
+  const walletMap = new Registry<SendingAccount>([]);
+
+  if (isEvmAccounts(config)) {
+    for (const account of config) {
+      if (isMultisigConfig(account)) {
+        const wallet = createWallet(account.signer);
+        const multisigAccount: InitializedMultisig = {
+          ...account,
+          wallet: wallet,
+        };
+        walletMap.set(account.name, multisigAccount);
+      } else if (isSingleSigAccount(account)) {
+        walletMap.set(account.name, createWallet(account));
+      }
+    }
+  } else if (isKeyStore(config)) {
+    const files = fs.readdirSync(config.dir);
+    for (const file of files) {
+      const filePath = path.join(config.dir, file);
+      const json = fs.readFileSync(filePath, "utf8");
+      const wallet = ethers.Wallet.fromEncryptedJsonSync(
+        json,
+        config.password ?? ""
+      );
+      walletMap.set(wallet.address, wallet);
+    }
+  }
+  return walletMap;
+}

--- a/src/evm/schemas/wallet.ts
+++ b/src/evm/schemas/wallet.ts
@@ -1,0 +1,51 @@
+import { ethers } from 'ethers';
+import { z } from 'zod';
+
+export const wallet = z.union([
+  z.instanceof(ethers.Wallet),
+  z.instanceof(ethers.HDNodeWallet),
+]);
+
+export const privateKey = z
+  .object({
+    name: z.string().min(1),
+    // privateKey should be a hex string prefixed with 0x
+    privateKey: z.string().min(1),
+  })
+  .strict();
+
+export const mnemonic = z
+  .object({
+    name: z.string().min(1),
+    // a 12-word mnemonic; or more words per BIP-39 spec
+    mnemonic: z.string().min(1),
+    path: z.optional(z.string().min(1)),
+    index: z.optional(z.number().int().min(0)),
+  })
+  .strict();
+
+export const singleSigAccount = z.union([privateKey, mnemonic]);
+
+export type PrivateKey = z.infer<typeof privateKey>;
+export type Mnemonic = z.infer<typeof mnemonic>;
+export type SingleSigAccount = z.infer<typeof singleSigAccount>;
+
+export const isPrivateKey = (account: unknown): account is PrivateKey=> {
+  return privateKey.safeParse(account).success;
+};
+
+export const isMnemonic = (account: unknown): account is Mnemonic=> {
+  return mnemonic.safeParse(account).success;
+};
+
+export const isSingleSigAccount = (
+  account: unknown
+): account is SingleSigAccount=> {
+  return singleSigAccount.safeParse(account).success;
+};
+
+export const isWallet = (account: unknown): account is Wallet => {
+  return wallet.safeParse(account).success;
+}
+
+export type Wallet = ethers.Wallet | ethers.HDNodeWallet;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { AccountRegistry } from "./evm/schemas/account";
+import { SingleSigAccountRegistry} from "./evm/schemas/account";
 import { Chain } from "./evm/chain";
 import { Registry } from "./utils/registry";
 import { ContractRegistryLoader } from "./evm/schemas/contract";
@@ -12,6 +12,6 @@ export {
   Registry,
   loadEvmAccounts,
   parseObjFromFile,
-  AccountRegistry,
+  SingleSigAccountRegistry,
   ContractRegistryLoader,
 };

--- a/src/multisig/safe.ts
+++ b/src/multisig/safe.ts
@@ -17,8 +17,6 @@ export const newSafeFromOwner = async (
   owners: string[],
   threshold: number
 ) => {
-  // TODO: check owners is indeed an array and not a string (for edge case of one address)
-
   const safeFactory = await SafeFactory.init({
     provider: RPC_URL,
     signer: ownerKey,

--- a/src/scripts/deploy-multisig.ts
+++ b/src/scripts/deploy-multisig.ts
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
 import { ethers } from "ethers";
-import { AccountRegistry, parseObjFromFile } from "..";
+import { SingleSigAccountRegistry, parseObjFromFile } from "..";
 import { newSafeFromOwner } from "../multisig/safe";
 
 import {
-  parseMultiSigInitArgsFromCLI,
+  parseMultisigInitArgsFromCLI,
   saveMultisigAddressToAccountsSpec,
 } from "../utils/io";
 
 async function main() {
   const { rpcUrl, owners, initiator, accountsSpecPath, threshold } =
-    await parseMultiSigInitArgsFromCLI();
+    await parseMultisigInitArgsFromCLI();
 
   const accountConfigFromYaml = {
     name: "multisig-accounts",
     registry: parseObjFromFile(accountsSpecPath),
   };
 
-  const accounts = AccountRegistry.loadMultiple([
+  const accounts = SingleSigAccountRegistry.loadMultiple([
     accountConfigFromYaml,
   ]).mustGet("multisig-accounts");
 

--- a/src/scripts/execute-multisig-tx.ts
+++ b/src/scripts/execute-multisig-tx.ts
@@ -1,23 +1,22 @@
 #!/usr/bin/env node
-import { AccountRegistry, parseObjFromFile } from "..";
-import { executeMultisigTx} from "../multisig/safe";
+import { parseObjFromFile } from "..";
+import { executeMultisigTx } from "../multisig/safe";
 
-import {
-  parseExecuteMultisigTxArgsFromCLI,
-} from "../utils/io";
-import { isParsedMultiSigWallet } from "../evm/schemas/account";
+import { parseExecuteMultisigTxArgsFromCLI } from "../utils/io";
+import { isInitializedMultisig } from "../evm/schemas/multisig";
+import { SendingAccountRegistry } from "../evm/schemas/sendingAccount";
 
 async function main() {
   const { executor, rpcUrl, txIndex, accountsSpecPath } =
     await parseExecuteMultisigTxArgsFromCLI();
 
-  const accounts = AccountRegistry.load(
+  const accounts = SendingAccountRegistry.load(
     parseObjFromFile(accountsSpecPath),
     "multisig-accounts"
   );
 
   const multisigAccount = accounts.mustGet(executor);
-  if (!isParsedMultiSigWallet(multisigAccount)) {
+  if (!isInitializedMultisig(multisigAccount)) {
     throw new Error("Can only execute transactions on a multisig wallet");
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -44,8 +44,8 @@ export const UPDATE_SPECS_PATH = process.env.UPDATE_SPECS_PATH
   ? process.env.UPDATE_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "update.spec.yaml");
 
-export const ACCOUNTS_SPECS_PATH = process.env.ACCOUNTS_SPECS_PATH
-  ? process.env.ACCOUNTS_SPECS_PATH
+export const ACCOUNT_SPECS_PATH = process.env.ACCOUNT_SPECS_PATH
+  ? process.env.ACCOUNT_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "evm.accounts.yaml");
 
 export const EXTRA_BINDINGS_PATH = process.env.EXTRA_BINDINGS_PATH;

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -28,6 +28,7 @@ import { hideBin } from 'yargs/helpers';
 import { SingleSigAccountRegistry } from '../evm/schemas/account';
 import { ethers } from 'ethers';
 import { BigNumberish } from 'ethers';
+import { SendingAccountRegistry } from '../evm/schemas/sendingAccount';
 
 export interface StringToStringMap {
   [key: string]: string | null | undefined;
@@ -272,7 +273,7 @@ export async function writeDeployedContractToFile(
 // Read existing accounts into env
 export async function readAccountsIntoEnv(
   env: any,
-  accountRegistry: SingleSigAccountRegistry
+  accountRegistry: SingleSigAccountRegistry| SendingAccountRegistry
 ) {
   accountRegistry.keys().forEach((accountName) => {
     env[accountName] = accountRegistry.mustGet(accountName);
@@ -417,7 +418,7 @@ export async function parseArgsFromCLI() {
     registry: parseObjFromFile(accountSpecs),
   };
 
-  const accounts = SingleSigAccountRegistry.loadMultiple([accountConfigFromYaml]);
+  const accounts = SendingAccountRegistry.loadMultiple([accountConfigFromYaml]);
 
   return {
     chain: chainParse.data,

--- a/src/utils/io.ts
+++ b/src/utils/io.ts
@@ -25,7 +25,7 @@ import {
 } from './constants';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
-import { AccountRegistry } from '../evm/schemas/account';
+import { SingleSigAccountRegistry } from '../evm/schemas/account';
 import { ethers } from 'ethers';
 import { BigNumberish } from 'ethers';
 
@@ -204,7 +204,7 @@ export async function readArtifactFile(
     }
   }
 
-  console.error(`error reading from file in extra file ${path}: \n`, e);
+  console.error(`error reading from file in extra file ${path}: \n`);
   return '';
 }
 
@@ -272,7 +272,7 @@ export async function writeDeployedContractToFile(
 // Read existing accounts into env
 export async function readAccountsIntoEnv(
   env: any,
-  accountRegistry: AccountRegistry
+  accountRegistry: SingleSigAccountRegistry
 ) {
   accountRegistry.keys().forEach((accountName) => {
     env[accountName] = accountRegistry.mustGet(accountName);
@@ -417,7 +417,7 @@ export async function parseArgsFromCLI() {
     registry: parseObjFromFile(accountSpecs),
   };
 
-  const accounts = AccountRegistry.loadMultiple([accountConfigFromYaml]);
+  const accounts = SingleSigAccountRegistry.loadMultiple([accountConfigFromYaml]);
 
   return {
     chain: chainParse.data,
@@ -432,7 +432,7 @@ export async function parseArgsFromCLI() {
   };
 }
 
-export const parseMultiSigInitArgsFromCLI = async () => {
+export const parseMultisigInitArgsFromCLI = async () => {
   const argv1 = await yargs(hideBin(process.argv)).option('OWNERS', {
     alias: 'o',
     description: 'Owners to init multisig safe with',


### PR DESCRIPTION
This PR Separates sendingAccounts into two different registries. On one hand, having the account registry return both single and multisig types is not great for contexts where we only need single sig accounts (e.g. e2e) since we have to typeguard everywhere to properly parse data. 

OTOH, to make infra integration easier, it would be nice to have support for being able to specify multiple accounts types (multisig vs single sig) from a single account spec file. 

This PR solves this by having two exported account registry types - one called `SingleSigAccountRegistry` and one called `SendingAccountRegistry`. We can move our e2e from using the generic account registry to a `SingleSigAccountRegistry`, while having our infra use the `SendingAccountRegistry`
