### PR TITLE
Raunak/multisig from spec

### DIFF
--- a/src/evm/schemas/account.ts
+++ b/src/evm/schemas/account.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import { Registry } from "../../utils/registry";
 import { renderString } from "../../utils/io";
-import { initializedMultisig } from "./multisig";
+import { initializedMultisigConfig, uninitializedMultisigConfig } from "./multisig";
 import {
   isMnemonic,
   isPrivateKey,
@@ -24,7 +24,7 @@ const keyStore = z.object({
 export type KeyStore = z.infer<typeof keyStore>;
 
 export const evmAccounts = z.array(
-  z.union([singleSigAccount, initializedMultisig])
+  z.union([singleSigAccount, initializedMultisigConfig, uninitializedMultisigConfig])
 ); // Type of account that one can send transactions from
 export type EvmAccounts = z.infer<typeof evmAccounts>;
 export const EvmAccountsConfig = z.union([evmAccounts, keyStore]);
@@ -104,7 +104,7 @@ export class SingleSigAccountRegistry extends Registry<Wallet> {
 // load a Map of { [name: string]: Wallet } from EvmAccountsSchema object
 export function loadEvmAccounts(config: unknown): Registry<Wallet> {
   if (!isEvmAccountsConfig(config)) {
-    throw new Error(`Error parsing schema: ${config}`);
+    throw new Error(`Error parsing schema: ${config}: \n ${EvmAccountsConfig.safeParse(config).error}`);
   }
   const walletMap = new Registry<Wallet>([]);
 

--- a/src/evm/schemas/multisig.ts
+++ b/src/evm/schemas/multisig.ts
@@ -1,37 +1,52 @@
 import { z } from 'zod';
-import {singleSigAccount, wallet} from './wallet';
+import { wallet } from './wallet';
 
-// defined in an account spec, which will be cconvertedi nto an initialized multisig config once we deploy the multisig contract
-export const uninitializedMultisigConfig = z.object({
-  name: z.string().min(1),
-  chainId: z.number(),
-  owners: z.array(z.string().min(1)), 
-  signer: singleSigAccount 
-}) .strict()
+// defined in an account spec, which will be converted into an initialized multisig config once we deploy the multisig contract
+export const uninitializedMultisigConfig = z
+  .object({
+    name: z.string().min(1),
+    chainId: z.number(),
+    privateKey: z.string().min(1),
+    owners: z.array(z.string().min(1)),
+    threshold: z.number(),
+  })
+  .strict();
 
 // Defined in an account spec, which is not necessarily in a config
-export const initializedMultisigConfig = z.object({
-  name: z.string().min(1),
-  chainId: z.number(),
-  safeAddress: z.string().min(1),
-  signer: singleSigAccount 
-}) .strict()
-
+export const initializedMultisigConfig = z
+  .object({
+    name: z.string().min(1),
+    chainId: z.number(),
+    privateKey: z.string().min(1),
+    safeAddress: z.string().min(1),
+  })
+  .strict();
 
 // Multisig which is described in an account spec but is not yet initialized. (i.e. multisig contract has not been deployed yet)
-export const unInitializedMultisig = z.intersection(
-    uninitializedMultisigConfig,
-    z.object({wallet: wallet})
-)
+export const unInitializedMultisig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  privateKey: z.string().min(1),
+  owners: z.array(z.string().min(1)),
+  threshold: z.number(),
+  wallet: wallet,
+});
 
 // Multisig which has been deployed & can be used to propose transactions. This is the type that loadEvmAccounts will return for multisig types
-export const initializedMultisig = z.intersection(
-  initializedMultisigConfig,
-    z.object({wallet: wallet})
-);
+export const initializedMultisig = z.object({
+  name: z.string().min(1),
+  chainId: z.number(),
+  privateKey: z.string().min(1),
+  safeAddress: z.string().min(1),
+  wallet: wallet,
+});
 
-export type UninitializedMultisigConfig = z.infer<typeof uninitializedMultisigConfig>;
-export type InitializedMultisigConfig = z.infer<typeof initializedMultisigConfig>;
+export type UninitializedMultisigConfig = z.infer<
+  typeof uninitializedMultisigConfig
+>;
+export type InitializedMultisigConfig = z.infer<
+  typeof initializedMultisigConfig
+>;
 export type UninitializedMultisig = z.infer<typeof unInitializedMultisig>;
 export type InitializedMultisig = z.infer<typeof initializedMultisig>;
 
@@ -41,7 +56,7 @@ export const isUninitializedMultisigConfig = (
 ): account is UninitializedMultisigConfig => {
   return uninitializedMultisigConfig.safeParse(account).success;
 };
-  
+
 export const isUninitializedMultisig = (
   account: unknown
 ): account is UninitializedMultisig => {
@@ -60,10 +75,17 @@ export const isInitializedMultisig = (
   return initializedMultisig.safeParse(account).success;
 };
 
-export const isMultisig = (account: unknown): account is InitializedMultisig | UninitializedMultisig => {
+export const isMultisig = (
+  account: unknown
+): account is InitializedMultisig | UninitializedMultisig => {
   return isInitializedMultisig(account) || isUninitializedMultisig(account);
 };
 
-export const isMultisigConfig = (account: unknown): account is InitializedMultisigConfig | UninitializedMultisigConfig => {
-  return isInitializedMultisigConfig(account) || isUninitializedMultisigConfig(account);
-}
+export const isMultisigConfig = (
+  account: unknown
+): account is InitializedMultisigConfig | UninitializedMultisigConfig => {
+  return (
+    isInitializedMultisigConfig(account) ||
+    isUninitializedMultisigConfig(account)
+  );
+};

--- a/src/multisig/safe.ts
+++ b/src/multisig/safe.ts
@@ -17,8 +17,6 @@ export const newSafeFromOwner = async (
   owners: string[],
   threshold: number
 ) => {
-  // TODO: check owners is indeed an array and not a string (for edge case of one address)
-
   const safeFactory = await SafeFactory.init({
     provider: RPC_URL,
     signer: ownerKey,

--- a/src/scripts/execute-multisig-tx.ts
+++ b/src/scripts/execute-multisig-tx.ts
@@ -1,23 +1,22 @@
 #!/usr/bin/env node
-import { AccountRegistry, parseObjFromFile } from "..";
-import { executeMultisigTx} from "../multisig/safe";
+import { parseObjFromFile } from "..";
+import { executeMultisigTx } from "../multisig/safe";
 
-import {
-  parseExecuteMultisigTxArgsFromCLI,
-} from "../utils/io";
-import { isParsedMultiSigWallet } from "../evm/schemas/account";
+import { parseExecuteMultisigTxArgsFromCLI } from "../utils/io";
+import { isInitializedMultisig } from "../evm/schemas/multisig";
+import { SendingAccountRegistry } from "../evm/schemas/sendingAccount";
 
 async function main() {
   const { executor, rpcUrl, txIndex, accountsSpecPath } =
     await parseExecuteMultisigTxArgsFromCLI();
 
-  const accounts = AccountRegistry.load(
+  const accounts = SendingAccountRegistry.load(
     parseObjFromFile(accountsSpecPath),
     "multisig-accounts"
   );
 
   const multisigAccount = accounts.mustGet(executor);
-  if (!isParsedMultiSigWallet(multisigAccount)) {
+  if (!isInitializedMultisig(multisigAccount)) {
     throw new Error("Can only execute transactions on a multisig wallet");
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -44,8 +44,8 @@ export const UPDATE_SPECS_PATH = process.env.UPDATE_SPECS_PATH
   ? process.env.UPDATE_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "update.spec.yaml");
 
-export const ACCOUNTS_SPECS_PATH = process.env.ACCOUNTS_SPECS_PATH
-  ? process.env.ACCOUNTS_SPECS_PATH
+export const ACCOUNT_SPECS_PATH = process.env.ACCOUNT_SPECS_PATH
+  ? process.env.ACCOUNT_SPECS_PATH
   : path.resolve(SPECS_BASE_PATH, "evm.accounts.yaml");
 
 export const EXTRA_BINDINGS_PATH = process.env.EXTRA_BINDINGS_PATH;


### PR DESCRIPTION
Instead of having to pass in all arguments (owners, threshold, signing privatekey , chainId) needed to create a multisg , this PR adds support for specifying an initialized and uninitialized multisig type in accounts spec. This makes the infra integration a lot easier 