### PR TITLE
patch fork deployment test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "4.0.7",
+  "version": "4.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-ibc/vibc-core-smart-contracts",
-      "version": "4.0.7",
+      "version": "4.0.9",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-ibc/vibc-core-smart-contracts",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "main": "dist/index.js",
   "bin": {
     "verify-vibc-core-smart-contracts": "./dist/scripts/verify-contract-script.js",

--- a/src/scripts/fork-deployment-test.ts
+++ b/src/scripts/fork-deployment-test.ts
@@ -63,7 +63,9 @@ const startAnvilServer = async (
   port: string,
   outFileName: string
 ) => {
-  const p = $`anvil --port ${port} --fork-url ${rpcUrl}`.pipe(
+  const p = $`anvil --port ${port} --fork-url ${rpcUrl}`
+
+  p.pipe(
     createWriteStream(outFileName)
   );
   await waitForAnvilServer(outFileName);


### PR DESCRIPTION
PR to fix the `anvil.kill() is not a function` in infra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version number from 4.0.8 to 4.0.9 in the package configuration.
	- Refined the process for starting the Anvil server, improving clarity in process management without affecting core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->