### PR TITLE
fix: Typos README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Accounts can either be normal evm accounts or multisig accounts.
 
 Normal accounts contain the following fields:
 - name - the name of the account, this can be referenced in the contracts update spec file in the `deployer` attribute. 
-- private key - the pivate key of the account. To avoid having to persist private keys in this account spec, you can also reference env variables through enclosing them in double brackets. For example, if there is a `DEPLOYER_PRIVATE_KEY` variable set in the environment that runs a command that references this account spec, you can set the private key attribute to `{{DEPLOYER_PRIVATE_KEY}}` and this will be rendered to the environment value during runtime. 
+- private key - the private key of the account. To avoid having to persist private keys in this account spec, you can also reference env variables through enclosing them in double brackets. For example, if there is a `DEPLOYER_PRIVATE_KEY` variable set in the environment that runs a command that references this account spec, you can set the private key attribute to `{{DEPLOYER_PRIVATE_KEY}}` and this will be rendered to the environment value during runtime. 
 
 Multisig accounts contain the following fields: 
 - name: The name of the account similar to normal accounts
-- private key: Private key of an owner account associated with the multsig account at the safeAddress.  Similar to normal accounts, you can reference env variables through enclosing them in double brackets.
+- private key: Private key of an owner account associated with the multisig account at the safeAddress.  Similar to normal accounts, you can reference env variables through enclosing them in double brackets.
 - safeAddress: The address of the multisig contract 
 - chainId : The chainId this multisig account exists on.
 


### PR DESCRIPTION
## Description

Corrected typographical errors in the `README.md` file. Fixed the following:  
- "pivate" → "private"  
- "multsig" → "multisig"  

These changes improve clarity and maintain a professional tone in the documentation.

## Changes Made
- Fixed typo in the "Normal accounts" section:  
  `pivate key` → `private key`
- Fixed typo in the "Multisig accounts" section:  
  `multsig account` → `multisig account`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and consistency in the descriptions of private keys for normal and multisig accounts.
	- Corrected the term "multsig" to "multisig" throughout the document.
	- Removed redundant space before colons in field descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->