### PR TITLE
generate go bindings in one package per contract/library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,11 @@ bindings-gen-go: build-contracts
 			continue; \
 		fi; \
 		type=$$(basename $$abi_file .abi.json); \
-		pkg=$$(basename $$abi_base .sol | tr "[:upper:]" "[:lower:]"); \
+		pkg=$$(basename $$type .sol | tr "[:upper:]" "[:lower:]"); \
 		mkdir -p ./bindings/go/$$pkg; \
 		abigen --abi $$abi_file --pkg $$pkg --type $$type --out ./bindings/go/$$pkg/$$type.go; \
 	done; \
+	go build ./... || exit 1; \
 	echo "Done."
 
 bindings-gen-ts: build-contracts

--- a/bindings/go/iappstateverifier/IAppStateVerifier.go
+++ b/bindings/go/iappstateverifier/IAppStateVerifier.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package iproofverifier
+package iappstateverifier
 
 import (
 	"errors"

--- a/bindings/go/ibceventsemitter/IbcEventsEmitter.go
+++ b/bindings/go/ibceventsemitter/IbcEventsEmitter.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package ibcdispatcher
+package ibceventsemitter
 
 import (
 	"errors"

--- a/bindings/go/ibcpacketsender/IbcPacketSender.go
+++ b/bindings/go/ibcpacketsender/IbcPacketSender.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package ibcdispatcher
+package ibcpacketsender
 
 import (
 	"errors"

--- a/bindings/go/iclientupdates/IClientUpdates.go
+++ b/bindings/go/iclientupdates/IClientUpdates.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package ilightclient
+package iclientupdates
 
 import (
 	"errors"

--- a/bindings/go/panickingmars/PanickingMars.go
+++ b/bindings/go/panickingmars/PanickingMars.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package mars
+package panickingmars
 
 import (
 	"errors"

--- a/bindings/go/protochannel/ProtoChannel.go
+++ b/bindings/go/protochannel/ProtoChannel.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package channel
+package protochannel
 
 import (
 	"errors"

--- a/bindings/go/protocounterparty/ProtoCounterparty.go
+++ b/bindings/go/protocounterparty/ProtoCounterparty.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package channel
+package protocounterparty
 
 import (
 	"errors"

--- a/bindings/go/revertingbytesmars/RevertingBytesMars.go
+++ b/bindings/go/revertingbytesmars/RevertingBytesMars.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package mars
+package revertingbytesmars
 
 import (
 	"errors"

--- a/bindings/go/revertingemptymars/RevertingEmptyMars.go
+++ b/bindings/go/revertingemptymars/RevertingEmptyMars.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package mars
+package revertingemptymars
 
 import (
 	"errors"

--- a/bindings/go/revertingstringclosechannelmars/RevertingStringCloseChannelMars.go
+++ b/bindings/go/revertingstringclosechannelmars/RevertingStringCloseChannelMars.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package mars
+package revertingstringclosechannelmars
 
 import (
 	"errors"

--- a/bindings/go/revertingstringmars/RevertingStringMars.go
+++ b/bindings/go/revertingstringmars/RevertingStringMars.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package mars
+package revertingstringmars
 
 import (
 	"errors"


### PR DESCRIPTION
PR to make each contract _wihtin each sol file_ have it's own module. 

Previously, if we ran the `make bindings-gen-go` command, it would produce go files which would not build for the mars contract, since it would declare all contracts declared in the `contracts/examples/Mars.sol` (Mars, PanicingMars, etc) as part of one go module. This would produce errors if you tried to build the go bindings using `go build ./...` because it would result in doubly-declaring certain structs (e.g. AckPacket for Mars contracts). To allow our go bindings to be robust to having multiple contracts to be declared in the same sol files, we can declare each contract as part of it's own package. 

This should only impact users of the reverting/panicking mars (of which there are none), and  `IbcDispatcher` go bindings