### PR TITLE
modify go bindings generation to fail if abi gen isn't found

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           MODULE_ROOT_PATH: "./"                                                                      
           RPC_URL: ${{ secrets.FORK_RPC_URL }}
+          RUN_FORK_TEST: true 
           CHAIN_NAME: "fork-test-ci"
           DUMMY_DEPLOYER_PRIVATE_KEY: ${{ secrets.DUMMY_DEPLOYER_PRIVATE_KEY }}
           DAPP_PRIVATE_KEY_1: ${{ secrets.DAPP_PRIVATE_KEY_1 }}


### PR DESCRIPTION
Despite us attempting to check go bindings in our CI, our `make bindings-gen-go` command was not properly checking 
- we weren't properly installing `abigen` since we were using `go install` instead of `go get` which needs to be used for our go version
- this resulted in a silent (i.e. still with exit code of 0 rather than 1 ) failure which made our check bindings CI workflow proceed without properly generating go bindings 


This change makes it so that if abi gen isn't installed properly, the CI will fail so that we proprely check our go binding generation 

